### PR TITLE
Convert ANSI color codes to HTML to color the logs

### DIFF
--- a/ros2launch_gui/qt/process_output_widget.py
+++ b/ros2launch_gui/qt/process_output_widget.py
@@ -1,7 +1,57 @@
-
+import re
 from python_qt_binding.QtWidgets import QPlainTextEdit
 from python_qt_binding.QtWidgets import QVBoxLayout
 from python_qt_binding.QtWidgets import QWidget
+
+# ANSI color code mapping to HTML colors
+ANSI_COLOR_MAP = {
+    '30': '#FFFFFF',  # Black
+    '31': '#FF0000',  # Red
+    '32': '#00FF00',  # Green
+    '33': '#FF7F00',  # Yellow (actually Orange for better readability)
+    '34': '#0000FF',  # Blue
+    '35': '#FF00FF',  # Magenta
+    '36': '#00FFFF',  # Cyan
+    '37': '#FFFFFF',  # White (actually Black to see it on white background)
+}
+
+# Regular expression to match ANSI escape codes
+ansi_color_re = re.compile(r'\033\[([0-9;]*)m')
+
+def ansi_to_html(text):
+    matches = ansi_color_re.match(text)
+    if not matches:
+        return text
+    codes = matches.group(1).split(';')
+    # remove the ANSI escape codes from the text
+    text = ansi_color_re.sub('', text)
+    if not codes:
+        return text
+
+    modifier = None
+    color_code = None
+    # reset case
+    if codes[0] == '0':
+        return text
+    # color + modifier
+    if len(codes) > 1:
+        modifier = codes[0]
+        color_code = ANSI_COLOR_MAP.get(codes[1])
+    # only color code present
+    else:
+        color_code = ANSI_COLOR_MAP.get(codes[0])
+
+    html_start = f'<span style="color: {color_code}">'
+    html_end = '</span>'
+    if modifier == '1':
+        html_text = f'{html_start}<b>{text}</b>{html_end}'
+    elif modifier == '3':
+        html_text = f'{html_start}<i>{text}</i>{html_end}'
+    elif modifier == '4':
+        html_text = f'{html_start}<u>{text}</u>{html_end}'
+    else:
+        html_text = f'{html_start}{text}{html_end}'
+    return html_text
 
 class ProcessOutputWidget(QWidget):
     """Widget to display output from launch processes."""
@@ -22,7 +72,11 @@ class ProcessOutputWidget(QWidget):
 
 
     def on_process_io(self, process_name, text):
-        if self.show_process_name:
-            self.text_edit.appendPlainText(f'[{process_name}] {text}')
-        else: 
-            self.text_edit.appendPlainText(text)
+        for line in text.split('\n'):
+            line = line.rstrip()
+            if line:
+                line = ansi_to_html(line)
+                if self.show_process_name:
+                    self.text_edit.appendHtml(f'[{process_name}] {line}')
+                else:
+                    self.text_edit.appendHtml(line)

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -1,0 +1,31 @@
+#import pytest
+from ros2launch_gui.qt.process_output_widget import ansi_to_html
+
+def test_plain_text_to_html():
+    input = "my text"
+    assert ansi_to_html(input) == input
+
+def test_info_text_to_html():
+    input = "\033[0m[INFO] my text\033[0m"
+    expected = '[INFO] my text'
+    assert ansi_to_html(input) == expected
+
+def test_colored_text_to_html():
+    input = "\033[31mmy text\033[0m"
+    expected = '<span style="color: #FF0000">my text</span>'
+    assert ansi_to_html(input) == expected
+
+def test_bold_colored_text_to_html():
+    input = "\033[1;32mmy text\033[0m"
+    expected = '<span style="color: #00FF00"><b>my text</b></span>'
+    assert ansi_to_html(input) == expected
+
+def test_underlined_colored_text_to_html():
+    input = "\033[4;34mmy text\033[0m"
+    expected = '<span style="color: #0000FF"><u>my text</u></span>'
+    assert ansi_to_html(input) == expected
+
+def test_italic_colored_text_to_html():
+    input = "\033[3;34mmy text\033[0m"
+    expected = '<span style="color: #0000FF"><i>my text</i></span>'
+    assert ansi_to_html(input) == expected


### PR DESCRIPTION
Hello Roland,

I also miss rosmon on ROS2 so I gave your tool a try. Thank you for building this.

When using `emulate_tty` in launch files to get colored logs (ERROR in red and WARN in yellow), we get some non printable characters in the log panel.

I have added some code to convert the ANSI color codes to HTML to be printed to the QPlainTextEdit.

I have also added some logic to split the input by lines because sometimes I get two lines in the string of the `on_process_io()` function. And skip empty lines to avoid blank lines in logs.

I have done the parsing of the ANSI code manually with a regex. I have seen that there is a module in [osrf_pycommon](https://github.com/osrf/osrf_pycommon/blob/f5ab4ff4674658821b237aeaa7e18e604e31c81c/osrf_pycommon/terminal_color/ansi_re.py) repo but it adds a dependency for nothing more than a regex definition.

You will see that I am not a Python developer so feel free to rewrite it in a more idiomatic way if you want.

If you think that this might be too slow, I also have a version that just removes the ANSI color codes with a compiled regex if you prefer: https://github.com/rolker/ros2launch_gui/compare/ros2...romainreignier:ros2launch_gui:feature/strip_ansi_codes