### PR TITLE
fix: add missing launch runtime dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,8 @@
   <depend>python_qt_binding</depend>
   <depend>ros2launch</depend>
 
+  <exec_depend>launch</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
## Summary
- Add `<exec_depend>launch</exec_depend>` to `package.xml`
- The `launch` package is imported throughout the package's core code path (`option/gui.py` → `actions/display_user_interface.py` → `api/user_interface.py`), making it a runtime dependency
- While `launch` is available transitively via the `ros2launch` dependency, direct imports should be explicitly declared per ROS 2 best practice
- Using `<exec_depend>` (not `<depend>`) because `launch` is a pure Python package with no build-time dependency

## Context
This fixes the pytest collection failure in the `unh_marine_autonomy` CI workflow (`docker-jazzy-ros-core`), which builds `ros2launch_gui` in the underlay workspace. Without `launch` as an explicit dependency, pytest collection fails with `ModuleNotFoundError: No module named 'launch'`.

Initially added as `<test_depend>`, updated to `<exec_depend>` per Copilot review feedback — `launch` is a runtime dependency, not test-only.

## Test plan
- [ ] Verify `colcon test --packages-select ros2launch_gui` collects and runs all tests successfully
- [ ] Verify CI passes

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`