### PR TITLE
feat: lazy Qt imports, ANSI parsing, tree views, event loop

### DIFF
--- a/ros2launch_gui/ansi.py
+++ b/ros2launch_gui/ansi.py
@@ -1,0 +1,52 @@
+import re
+
+# ANSI color code mapping to HTML colors
+ANSI_COLOR_MAP = {
+    '30': '#FFFFFF',  # Black
+    '31': '#FF0000',  # Red
+    '32': '#00FF00',  # Green
+    '33': '#FF7F00',  # Yellow (actually Orange for better readability)
+    '34': '#0000FF',  # Blue
+    '35': '#FF00FF',  # Magenta
+    '36': '#00FFFF',  # Cyan
+    '37': '#FFFFFF',  # White (actually Black to see it on white background)
+}
+
+# Regular expression to match ANSI escape codes
+ansi_color_re = re.compile(r'\033\[([0-9;]*)m')
+
+
+def ansi_to_html(text):
+    matches = ansi_color_re.match(text)
+    if not matches:
+        return text
+    codes = matches.group(1).split(';')
+    # remove the ANSI escape codes from the text
+    text = ansi_color_re.sub('', text)
+    if not codes:
+        return text
+
+    modifier = None
+    color_code = None
+    # reset case
+    if codes[0] == '0':
+        return text
+    # color + modifier
+    if len(codes) > 1:
+        modifier = codes[0]
+        color_code = ANSI_COLOR_MAP.get(codes[1])
+    # only color code present
+    else:
+        color_code = ANSI_COLOR_MAP.get(codes[0])
+
+    html_start = f'<span style="color: {color_code}">'
+    html_end = '</span>'
+    if modifier == '1':
+        html_text = f'{html_start}<b>{text}</b>{html_end}'
+    elif modifier == '3':
+        html_text = f'{html_start}<i>{text}</i>{html_end}'
+    elif modifier == '4':
+        html_text = f'{html_start}<u>{text}</u>{html_end}'
+    else:
+        html_text = f'{html_start}{text}{html_end}'
+    return html_text

--- a/ros2launch_gui/ansi.py
+++ b/ros2launch_gui/ansi.py
@@ -16,37 +16,73 @@ ANSI_COLOR_MAP = {
 ansi_color_re = re.compile(r'\033\[([0-9;]*)m')
 
 
-def ansi_to_html(text):
-    matches = ansi_color_re.match(text)
-    if not matches:
-        return text
-    codes = matches.group(1).split(';')
-    # remove the ANSI escape codes from the text
-    text = ansi_color_re.sub('', text)
-    if not codes:
-        return text
+def _parse_codes(codes):
+    """Parse ANSI code list into (modifier, color) tuple.
 
+    Returns (modifier_tag, color_hex) where modifier_tag is 'b', 'i', 'u',
+    or None, and color_hex is an HTML color string or None.
+    """
     modifier = None
-    color_code = None
-    # reset case
-    if codes[0] == '0':
-        return text
-    # color + modifier
-    if len(codes) > 1:
-        modifier = codes[0]
-        color_code = ANSI_COLOR_MAP.get(codes[1])
-    # only color code present
-    else:
-        color_code = ANSI_COLOR_MAP.get(codes[0])
+    color = None
 
-    html_start = f'<span style="color: {color_code}">'
-    html_end = '</span>'
-    if modifier == '1':
-        html_text = f'{html_start}<b>{text}</b>{html_end}'
-    elif modifier == '3':
-        html_text = f'{html_start}<i>{text}</i>{html_end}'
-    elif modifier == '4':
-        html_text = f'{html_start}<u>{text}</u>{html_end}'
-    else:
-        html_text = f'{html_start}{text}{html_end}'
-    return html_text
+    for code in codes:
+        if code == '1':
+            modifier = 'b'
+        elif code == '3':
+            modifier = 'i'
+        elif code == '4':
+            modifier = 'u'
+        elif code in ANSI_COLOR_MAP:
+            color = ANSI_COLOR_MAP[code]
+
+    return modifier, color
+
+
+def ansi_to_html(text):
+    """Convert ANSI color codes in text to HTML spans.
+
+    Handles multiple color regions per line, mid-line color changes,
+    reset codes, and modifier+color combinations.
+    """
+    parts = ansi_color_re.split(text)  # [text, codes, text, codes, ...]
+    if len(parts) == 1:
+        return text  # no ANSI codes — fast path
+
+    result = []
+    in_span = False
+    pending_modifier = None
+
+    for i, part in enumerate(parts):
+        if i % 2 == 1:
+            # ANSI code group (captured group from split)
+            if in_span:
+                result.append('</span>')
+                in_span = False
+                pending_modifier = None
+
+            codes = part.split(';')
+            if codes == ['0'] or codes == ['']:
+                # Reset or empty — just close the span (already done above)
+                continue
+
+            modifier, color = _parse_codes(codes)
+            if color:
+                result.append(f'<span style="color: {color}">')
+                in_span = True
+                pending_modifier = modifier
+            # If no recognized color, skip (gracefully strip unknown codes)
+        else:
+            # Text segment
+            if part:
+                if pending_modifier and in_span:
+                    result.append(
+                        f'<{pending_modifier}>{part}</{pending_modifier}>'
+                    )
+                else:
+                    result.append(part)
+                pending_modifier = None
+
+    if in_span:
+        result.append('</span>')
+
+    return ''.join(result)

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -126,11 +126,11 @@ def describe_condition(condition: Condition, context: LaunchContext) -> str:
 def describe_substitution(substitution, context: LaunchContext) -> str:
     if substitution is None:
         return ''
-    if context is not None:
-        try:
+    try:
+        if context is not None:
             return perform_substitutions(context, normalize_to_list_of_substitutions(substitution))
-        except Exception as e:
-            pass
-    
-    return format_substitutions(substitution)
-
+        else:
+            return format_substitutions(substitution)
+    except Exception as e:
+        print(e)
+        return str(substitution)

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -71,7 +71,15 @@ class DescribedLaunchEntity:
             self.description = launch_entity.launch_description_source.location
             self.launch_arguments = []
             for la in launch_entity.launch_arguments:
-                self.launch_arguments.append((describe_substitution(la[0], context), describe_substitution(la[1], context)))
+                try:
+                    la0 = describe_substitution(la[0], context)
+                except Exception as e:
+                    la0 = str(la[0])
+                try:
+                    la1 = describe_substitution(la[1], context)
+                except Exception as e:
+                    la1 = str(la[1])
+                self.launch_arguments.append((la0, la1))
 
         elif isinstance(launch_entity, DeclareLaunchArgument):
             self.label = str(launch_entity.name)
@@ -108,7 +116,10 @@ def describe_condition(condition: Condition, context: LaunchContext) -> str:
     if condition is not None:
         value = '?'
         if context is not None:
-            value = condition.evaluate(context)
+            try:
+                value = condition.evaluate(context)
+            except Exception as e:
+                value = str(e)
         return '{}: {}'.format(type(condition).__name__, value)
     return ''
 
@@ -116,6 +127,10 @@ def describe_substitution(substitution, context: LaunchContext) -> str:
     if substitution is None:
         return ''
     if context is not None:
-        return perform_substitutions(context, normalize_to_list_of_substitutions(substitution))
+        try:
+            return perform_substitutions(context, normalize_to_list_of_substitutions(substitution))
+        except Exception as e:
+            pass
+    
     return format_substitutions(substitution)
 

--- a/ros2launch_gui/api/user_interface.py
+++ b/ros2launch_gui/api/user_interface.py
@@ -47,7 +47,7 @@ class UserInterface:
             debug: bool = False
     ):
         
-        if(debug):
+        if debug:
             ui_handler = OnUserInterfaceEvent(self, debug=True, update_rate=1.0)
         else:
             ui_handler = OnUserInterfaceEvent(self)

--- a/ros2launch_gui/api/user_interface.py
+++ b/ros2launch_gui/api/user_interface.py
@@ -46,12 +46,22 @@ class UserInterface:
             launch_description: LaunchDescription,
             debug: bool = False
     ):
+        
+        if(debug):
+            ui_handler = OnUserInterfaceEvent(self, debug=True, update_rate=1.0)
+        else:
+            ui_handler = OnUserInterfaceEvent(self)
         self._pending_actions = [
-            RegisterEventHandler(OnUserInterfaceEvent(self, debug)),
+            RegisterEventHandler(ui_handler),
             EmitEvent(event=QueryUserInterface()),
             EmitEvent(event=IncludeLaunchDescription(launch_description))
         ]
         self._close_requested = False
+
+    def spin_once(self) -> None:
+        """Process a single iteration of the GUI event loop."""
+        # This method should be overridden by subclasses to implement the GUI event loop
+        raise NotImplementedError("Subclasses must implement spin_once()")
 
     def close(self) -> None:
         """Request the GUI to close."""

--- a/ros2launch_gui/event_handlers/on_user_interface_event.py
+++ b/ros2launch_gui/event_handlers/on_user_interface_event.py
@@ -6,10 +6,13 @@ from launch.events import Shutdown
 from ros2launch_gui.events import QueryUserInterface
 
 class OnUserInterfaceEvent(BaseEventHandler):
-    def __init__(self, ui, debug: bool = False):
+    def __init__(self, ui, debug: bool = False, update_rate: float = 5.0):
         super().__init__(matcher=lambda event: True)
         self._ui = ui
         self._debug = debug
+        if update_rate <= 0.0:
+            raise ValueError("Update rate must be greater than 0.0")
+        self._period = 1.0 / update_rate
 
     def handle(self, event, context):
         super().handle(event, context)
@@ -20,8 +23,9 @@ class OnUserInterfaceEvent(BaseEventHandler):
             self._ui = None
             return None
         if isinstance(event, QueryUserInterface):
+            self._ui.spin_once()
             return [TimerAction(
-                    period=0.5,
+                    period=self._period,
                     actions=[EmitEvent(event=QueryUserInterface())])
             ] + self._ui.get_pending_actions()
         try:

--- a/ros2launch_gui/qt/__init__.py
+++ b/ros2launch_gui/qt/__init__.py
@@ -1,5 +1,8 @@
-from .main import UserInterface
+__all__ = ['UserInterface']
 
-__all__ = [
-    'UserInterface',
-]
+
+def __getattr__(name):
+    if name == 'UserInterface':
+        from .main import UserInterface
+        return UserInterface
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -5,6 +5,7 @@ from typing import Callable
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtGui import QBrush
 from python_qt_binding.QtGui import QColor
+from python_qt_binding.QtWidgets import QCheckBox
 from python_qt_binding.QtWidgets import QMenu
 from python_qt_binding.QtWidgets import QTreeWidgetItem
 from python_qt_binding.QtWidgets import QTreeWidget
@@ -48,32 +49,60 @@ class LaunchDescriptionWidget(QWidget):
         ),
     }
 
+    tree_types = ('simple', 'detailed')
 
     def __init__(self, ui, parent=None):
         super().__init__(parent)
-
         self._ui = ui
-        self.tree = QTreeWidget(self)
-        self.tree.setHeaderLabels(['Launch Entity', 'Status', 'Name', 'Description'])
-        self.tree.header().resizeSection(0, 350)
-        self.tree.header().resizeSection(1, 75)
-        self.tree.header().resizeSection(2, 200)
 
-        self.tree.itemActivated.connect(self.on_item_selected)
-        self.tree.itemClicked.connect(self.on_item_selected)
-        self.tree.currentItemChanged.connect(self.on_item_selected)
+        self.show_detailed_configuration_checkbox = QCheckBox('Show Detailed Configuration', self)
 
-        self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.tree.customContextMenuRequested.connect(self.show_context_menu)
+        self.trees = {}
+        for tree_type in self.tree_types:
+            self.trees[tree_type] = self.create_tree_widget()
+            self.trees[tree_type].setObjectName(tree_type + '_tree')
+            self.trees[tree_type].setVisible(False)
+
+
+        self.show_detailed_configuration_checkbox.stateChanged.connect(self.show_detailed_configuration_checkbox_state_changed)
+        self.show_detailed_configuration_checkbox.setChecked(False)
+
 
         layout = QVBoxLayout()
-        layout.addWidget(self.tree)
+        layout.addWidget(self.show_detailed_configuration_checkbox)
+        for tree_type in self.tree_types:
+            layout.addWidget(self.trees[tree_type])
+        self.trees['simple'].show()
+
         self.setLayout(layout)
 
         self.entity_items = {}
         self.process_items = {}
         self.launch_arguments_items = {}
         self.entity_condition_items = {}
+
+    def create_tree_widget(self):
+        tree = QTreeWidget(self)
+        tree.setHeaderLabels(['Launch Entity', 'Status', 'Name', 'Description'])
+        tree.header().resizeSection(0, 350)
+        tree.header().resizeSection(1, 150)
+        tree.header().resizeSection(2, 400)
+
+        tree.itemActivated.connect(self.on_item_selected)
+        tree.itemClicked.connect(self.on_item_selected)
+        tree.currentItemChanged.connect(self.on_item_selected)
+
+        tree.setContextMenuPolicy(Qt.CustomContextMenu)
+        tree.customContextMenuRequested.connect(lambda pos: self.show_context_menu(pos, tree))
+        return tree
+
+    def show_detailed_configuration_checkbox_state_changed(self, state):
+        if state == Qt.Checked:
+            self.trees['simple'].hide()
+            self.trees['detailed'].show()
+        else:
+            self.trees['detailed'].hide()
+            self.trees['simple'].show()
 
 
     def on_item_selected(self, item, column):
@@ -83,8 +112,9 @@ class LaunchDescriptionWidget(QWidget):
                 selected_callback()
 
     def on_describe_launch_entity(self, entity: DescribedLaunchEntity) -> None:
-        self.add_launch_entity_to_tree(entity)
-        self.tree.expandAll()
+        self.add_launch_entity_to_trees(entity)
+        for tree_type in self.tree_types:
+            self.trees[tree_type].expandAll()
 
     def on_execution_complete(self, entity: DescribedLaunchEntity) -> None:
         self.updated_launch_entity(entity, status='done')
@@ -97,38 +127,47 @@ class LaunchDescriptionWidget(QWidget):
             selected_callback=None
     ) -> None:
         if process_name in self.process_items:
-            process_item = self.process_items[process_name]
+            process_items = self.process_items[process_name]
         else:
-            process_item = QTreeWidgetItem(['Process', 'running', process_name, f'PID: {pid}'])
-            self.process_items[process_name] = process_item
+            process_items = {}
+            for item_label in self.tree_types:
+                process_items[item_label] = QTreeWidgetItem(['Process', 'running', process_name, f'PID: {pid}'])
+            self.process_items[process_name] = process_items
         if entity.id in self.entity_items:
-            item = self.entity_items[entity.id]
-            item.addChild(process_item)
-            item.setExpanded(True)
+            items = self.entity_items[entity.id]
+            for tree_type in self.tree_types:
+                item = items[tree_type]
+                if item is not None:
+                    item.addChild(process_items[tree_type])
+                    item.setExpanded(True)
+                    item.setData(0, self.DetailsCallbackRole, selected_callback)
+
             if entity.type_name == "LifecycleNode":
                 self.on_state_transition(entity, 'unknown', 'unconfigured')
         else:
-            self.tree.addTopLevelItem(process_item)
+            for tree_type in self.tree_types:
+                self.trees[tree_type].addTopLevelItem(process_items[tree_type])
 
-        process_item.setText(1, 'running')
-        process_item.setText(3, f'PID: {pid}')
-        process_item.setData(0, self.DetailsCallbackRole, selected_callback)
-        process_item.setData(1, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
-        process_item.setData(
-            0,
-            self.ContextMenuRole,
-            lambda menu: menu.addAction(
-                f'Stop {process_name}',
-                lambda: self._ui.add_pending_action(
-                    EmitEvent(
-                        event=SignalProcess(
-                            signal_number= signal.SIGINT,
-                            process_matcher=matches_pid(pid)
+        for tree_type in self.tree_types:
+            process_items[tree_type].setText(1, 'running')
+            process_items[tree_type].setText(3, f'PID: {pid}')
+            process_items[tree_type].setData(0, self.DetailsCallbackRole, selected_callback)
+            process_items[tree_type].setData(3, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
+            process_items[tree_type].setData(
+                0,
+                self.ContextMenuRole,
+                lambda menu: menu.addAction(
+                    f'Stop {process_name}',
+                    lambda: self._ui.add_pending_action(
+                        EmitEvent(
+                            event=SignalProcess(
+                                signal_number= signal.SIGINT,
+                                process_matcher=matches_pid(pid)
+                            )
                         )
                     )
                 )
             )
-        )
 
     def get_lifecycle_menu_items(self, menu: QMenu, node_name: str, current_state: str) -> None:
         for label, transition_id in self.lifecycle_transitions[current_state]:
@@ -147,13 +186,15 @@ class LaunchDescriptionWidget(QWidget):
 
     def on_entity_process_exited(self, entity: DescribedLaunchEntity, process_name: str, pid: int, return_code) -> None:
         if process_name in self.process_items:
-            item = self.process_items[process_name]
-            item.setText(1, f'exit: {return_code}')
-            if return_code == 0:
-                item.setData(1, Qt.BackgroundRole, QBrush(QColor(200, 255, 200)))
-            else:
-                item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 128, 128)))
-            item.setData(0, self.ContextMenuRole, None)
+            items = self.process_items[process_name]
+            for tree_type in self.tree_types:
+                item = items[tree_type]
+                item.setText(1, f'exit: {return_code}')
+                if return_code == 0:
+                    item.setData(3, Qt.BackgroundRole, QBrush(QColor(210, 255, 200)))
+                else:
+                    item.setData(3, Qt.BackgroundRole, QBrush(QColor(255, 128, 128)))
+                item.setData(0, self.ContextMenuRole, None)
 
     def updated_launch_entity(self, launch_entity: DescribedLaunchEntity, status=None):
         if launch_entity.condition is not None:
@@ -161,96 +202,127 @@ class LaunchDescriptionWidget(QWidget):
                 item = self.entity_condition_items[launch_entity.id]
                 item.setText(2, launch_entity.condition)
         if launch_entity.id in self.entity_items:
-            item = self.entity_items[launch_entity.id]
-            item.setText(2, launch_entity.label)
-            item.setText(3, str(launch_entity.description))
-            if status is not None:
-                item.setText(1, status)
-            if launch_entity.type_name == "IncludeLaunchDescription":
-                for child in launch_entity.children:
-                    if child.id not in self.entity_items:
-                        self.add_launch_entity_to_tree(child, launch_entity)
+            items = self.entity_items[launch_entity.id]
+            for tree_type in self.tree_types:
+                item = items[tree_type]
+                if item is not None:
+                    item.setText(2, launch_entity.label)
+                    item.setText(3, str(launch_entity.description))
+                    if status is not None:
+                        item.setText(1, status)
+                if launch_entity.type_name == "IncludeLaunchDescription":
+                    for child in launch_entity.children:
+                        if child.id not in self.entity_items:
+                            self.add_launch_entity_to_trees(child, launch_entity)
         for child in launch_entity.children:
             self.updated_launch_entity(child)
 
     def on_state_transition(self, entity: DescribedLaunchEntity, start_state: str, goal_state: str) -> None:
         if entity.id in self.entity_items:
-            item = self.entity_items[entity.id]
-            item.setText(1, f'{goal_state}')
-            if goal_state == 'active':
-                item.setData(1, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
-            else:
-                item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
-            if goal_state in self.lifecycle_transitions:
-                item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, entity.label, goal_state))
-            else:
-                item.setData(0, self.ContextMenuRole, None)
+            items = self.entity_items[entity.id]
+            for tree_type in self.tree_types:
+                item = items[tree_type]
+                if item is not None:
+                    item.setText(1, f'{goal_state}')
+                    if goal_state == 'active':
+                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
+                    else:
+                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
+                    if goal_state in self.lifecycle_transitions:
+                        item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, entity.label, goal_state))
+                    else:
+                        item.setData(0, self.ContextMenuRole, None)
 
-    def add_launch_entity_to_tree(
+
+
+
+
+    def add_launch_entity_to_trees(
         self,
         launch_entity: DescribedLaunchEntity,
         parent: DescribedLaunchEntity=None,
         status=None
     ):
         if launch_entity.id in self.entity_items:
-            item = self.entity_items[launch_entity.id]
+            items = self.entity_items[launch_entity.id]
             if status is not None:
-                item.setText(1, status)
+                for tree_type in self.tree_types:
+                    item = items[tree_type]
+                    item.setText(1, status)
         else:
-            status_text = status if status is not None else ''
-            item = QTreeWidgetItem([launch_entity.type_name, status_text, launch_entity.label, str(launch_entity.description), status])
-            parent_item = None
-            expand_parent = True
-            if parent is not None:
-                if parent.id in self.entity_items:
-                    parent_item = self.entity_items[parent.id]
-                    if launch_entity.type_name == "DeclareLaunchArgument":
-                        if not parent.id in self.launch_arguments_items:
-                            self.launch_arguments_items[parent.id] = QTreeWidgetItem(['Launch Arguments', '', '', ''])
-                            parent_item.addChild(self.launch_arguments_items[parent.id])
-                        parent_item = self.launch_arguments_items[parent.id]
-                        expand_parent = False
-            if launch_entity.condition is not None:
-                if launch_entity.id in self.entity_condition_items:
-                    condition_item = self.entity_condition_items[launch_entity.id]
-                else:
-                    condition_item = QTreeWidgetItem(['Condition', '', launch_entity.condition, ''])
-                    self.entity_condition_items[launch_entity.id] = condition_item
+            items = {}
+            for tree_type in self.tree_types:
+                if tree_type != "simple" or launch_entity.type_name in ("Node", "LifecycleNode"):
+
+                    status_text = status if status is not None else ''
+                    item = QTreeWidgetItem([launch_entity.type_name, status_text, launch_entity.label, str(launch_entity.description), status])
+                    parent_item = None
+                    expand_parent = True
+                    if parent is not None:
+                        if parent.id in self.entity_items:
+                            parent_item = self.entity_items[parent.id][tree_type]
+                            if parent_item is not None:
+                                if launch_entity.type_name == "DeclareLaunchArgument":
+                                    if not parent.id in self.launch_arguments_items:
+                                        self.launch_arguments_items[parent.id] = QTreeWidgetItem(['Launch Arguments', '', '', ''])
+                                        parent_item.addChild(self.launch_arguments_items[parent.id])
+                                    parent_item = self.launch_arguments_items[parent.id]
+                                    expand_parent = False
+                    if tree_type == 'detailed':
+                        if launch_entity.condition is not None:
+                            if launch_entity.id in self.entity_condition_items:
+                                condition_item = self.entity_condition_items[launch_entity.id]
+                            else:
+                                condition_item = QTreeWidgetItem(['Condition', '', launch_entity.condition, ''])
+                                self.entity_condition_items[launch_entity.id] = condition_item
+                                if parent_item is not None:
+                                    parent_item.addChild(condition_item)
+                                    parent_item.setExpanded(True)
+                                else:
+                                    self.trees[tree_type].addTopLevelItem(condition_item)
+                            parent_item = condition_item
                     if parent_item is not None:
-                        parent_item.addChild(condition_item)
-                        parent_item.setExpanded(True)
+                        parent_item.addChild(item)
+                        if expand_parent:
+                            parent_item.setExpanded(True)
                     else:
-                        self.tree.addTopLevelItem(condition_item)
-                parent_item = condition_item
-            if parent_item is not None:
-                parent_item.addChild(item)
-                if expand_parent:
-                    parent_item.setExpanded(True)
-            else:
-                self.tree.addTopLevelItem(item)
-            item.setExpanded(True)
-            self.entity_items[launch_entity.id] = item
-            if launch_entity.type_name == "LifecycleNode":
-                item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
-                if status is None:
-                    # assuming lifecycle node is unconfigured until we know otherwise
-                    status = 'unconfigured'
-                if status in self.lifecycle_transitions:
-                    item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, launch_entity.label, status))
+                        self.trees[tree_type].addTopLevelItem(item)
+                    item.setExpanded(True)
+                    items[tree_type] = item
+                    self.update_lifecycle_callbacks(launch_entity, item, status)
+                else:
+                    items[tree_type] = None
+
+            self.entity_items[launch_entity.id] = items
             
 
         for child in launch_entity.children:
-            self.add_launch_entity_to_tree(child, launch_entity)
+            self.add_launch_entity_to_trees(child, launch_entity)
         for condition, sub_entities in launch_entity.conditional_children:
             for sub_entity in sub_entities:
-                self.add_launch_entity_to_tree(sub_entity, launch_entity)
+                self.add_launch_entity_to_trees(sub_entity, launch_entity)
 
-    def show_context_menu(self, pos):
-        item = self.tree.itemAt(pos)
+    def update_lifecycle_callbacks(
+        self,
+        launch_entity: DescribedLaunchEntity,
+        item: QTreeWidgetItem,
+        status: str
+    ):
+        if launch_entity.type_name == "LifecycleNode":
+            item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
+            if status is None:
+                # assuming lifecycle node is unconfigured until we know otherwise
+                status = 'unconfigured'
+            if status in self.lifecycle_transitions:
+                item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, launch_entity.label, status))
+        
+
+    def show_context_menu(self, pos, tree):
+        item = tree.itemAt(pos)
         if item is not None:
             context_menu_callback = item.data(0, self.ContextMenuRole)
             if context_menu_callback is not None:
                 menu = QMenu(self)
                 context_menu_callback(menu)
-                menu.exec_(self.tree.mapToGlobal(pos))
+                menu.exec_(tree.mapToGlobal(pos))
 

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -84,9 +84,9 @@ class LaunchDescriptionWidget(QWidget):
     def create_tree_widget(self):
         tree = QTreeWidget(self)
         tree.setHeaderLabels(['Launch Entity', 'Status', 'Name', 'Description'])
-        tree.header().resizeSection(0, 350)
+        tree.header().resizeSection(0, 200)
         tree.header().resizeSection(1, 150)
-        tree.header().resizeSection(2, 400)
+        tree.header().resizeSection(2, 275)
 
         tree.itemActivated.connect(self.on_item_selected)
         tree.itemClicked.connect(self.on_item_selected)
@@ -152,7 +152,7 @@ class LaunchDescriptionWidget(QWidget):
             process_items[tree_type].setText(1, 'running')
             process_items[tree_type].setText(3, f'PID: {pid}')
             process_items[tree_type].setData(0, self.DetailsCallbackRole, selected_callback)
-            process_items[tree_type].setData(3, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
+            process_items[tree_type].setData(1, Qt.BackgroundRole, QBrush(QColor(150, 255, 100)))
             process_items[tree_type].setData(
                 0,
                 self.ContextMenuRole,
@@ -191,9 +191,9 @@ class LaunchDescriptionWidget(QWidget):
                 item = items[tree_type]
                 item.setText(1, f'exit: {return_code}')
                 if return_code == 0:
-                    item.setData(3, Qt.BackgroundRole, QBrush(QColor(210, 255, 200)))
+                    item.setData(1, Qt.BackgroundRole, QBrush(QColor(150, 100, 100)))
                 else:
-                    item.setData(3, Qt.BackgroundRole, QBrush(QColor(255, 128, 128)))
+                    item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 128, 128)))
                 item.setData(0, self.ContextMenuRole, None)
 
     def updated_launch_entity(self, launch_entity: DescribedLaunchEntity, status=None):
@@ -225,9 +225,9 @@ class LaunchDescriptionWidget(QWidget):
                 if item is not None:
                     item.setText(1, f'{goal_state}')
                     if goal_state == 'active':
-                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(100, 255, 100)))
+                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(100, 255, 150)))
                     else:
-                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
+                        item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 150)))
                     if goal_state in self.lifecycle_transitions:
                         item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, entity.label, goal_state))
                     else:
@@ -309,7 +309,7 @@ class LaunchDescriptionWidget(QWidget):
         status: str
     ):
         if launch_entity.type_name == "LifecycleNode":
-            item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 100)))
+            item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 150)))
             if status is None:
                 # assuming lifecycle node is unconfigured until we know otherwise
                 status = 'unconfigured'

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -191,7 +191,7 @@ class LaunchDescriptionWidget(QWidget):
                 item = items[tree_type]
                 item.setText(1, f'exit: {return_code}')
                 if return_code == 0:
-                    item.setData(1, Qt.BackgroundRole, QBrush(QColor(150, 100, 100)))
+                    item.setData(1, Qt.BackgroundRole, QBrush(QColor(200, 255, 200)))
                 else:
                     item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 128, 128)))
                 item.setData(0, self.ContextMenuRole, None)

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -76,10 +76,14 @@ class UserInterface(UserInterfaceBase):
 
     async def run_qt(self, *args, **kwargs):
         while not self.closing:
-            if self.close_requested:
-                self.main_window.close()
-            self.app.processEvents()
+            self.spin_once()
             await asyncio.sleep(0.05)
+
+    def spin_once(self):
+        if self.close_requested:
+            self.main_window.close()
+        self.app.processEvents()
+
 
     def on_process_started(self, process_name, pid, action):
         self.main_window.on_process_started(action, process_name, pid)

--- a/ros2launch_gui/qt/process_output_widget.py
+++ b/ros2launch_gui/qt/process_output_widget.py
@@ -1,57 +1,9 @@
-import re
 from python_qt_binding.QtWidgets import QPlainTextEdit
 from python_qt_binding.QtWidgets import QVBoxLayout
 from python_qt_binding.QtWidgets import QWidget
 
-# ANSI color code mapping to HTML colors
-ANSI_COLOR_MAP = {
-    '30': '#FFFFFF',  # Black
-    '31': '#FF0000',  # Red
-    '32': '#00FF00',  # Green
-    '33': '#FF7F00',  # Yellow (actually Orange for better readability)
-    '34': '#0000FF',  # Blue
-    '35': '#FF00FF',  # Magenta
-    '36': '#00FFFF',  # Cyan
-    '37': '#FFFFFF',  # White (actually Black to see it on white background)
-}
+from ros2launch_gui.ansi import ansi_to_html
 
-# Regular expression to match ANSI escape codes
-ansi_color_re = re.compile(r'\033\[([0-9;]*)m')
-
-def ansi_to_html(text):
-    matches = ansi_color_re.match(text)
-    if not matches:
-        return text
-    codes = matches.group(1).split(';')
-    # remove the ANSI escape codes from the text
-    text = ansi_color_re.sub('', text)
-    if not codes:
-        return text
-
-    modifier = None
-    color_code = None
-    # reset case
-    if codes[0] == '0':
-        return text
-    # color + modifier
-    if len(codes) > 1:
-        modifier = codes[0]
-        color_code = ANSI_COLOR_MAP.get(codes[1])
-    # only color code present
-    else:
-        color_code = ANSI_COLOR_MAP.get(codes[0])
-
-    html_start = f'<span style="color: {color_code}">'
-    html_end = '</span>'
-    if modifier == '1':
-        html_text = f'{html_start}<b>{text}</b>{html_end}'
-    elif modifier == '3':
-        html_text = f'{html_start}<i>{text}</i>{html_end}'
-    elif modifier == '4':
-        html_text = f'{html_start}<u>{text}</u>{html_end}'
-    else:
-        html_text = f'{html_start}{text}{html_end}'
-    return html_text
 
 class ProcessOutputWidget(QWidget):
     """Widget to display output from launch processes."""

--- a/ros2launch_gui/tk/__init__.py
+++ b/ros2launch_gui/tk/__init__.py
@@ -1,5 +1,8 @@
-from .user_interface import UserInterface
+__all__ = ['UserInterface']
 
-__all__ = [
-    'UserInterface',
-]
+
+def __getattr__(name):
+    if name == 'UserInterface':
+        from .user_interface import UserInterface
+        return UserInterface
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ros2launch_gui/tk/user_interface.py
+++ b/ros2launch_gui/tk/user_interface.py
@@ -42,9 +42,14 @@ class UserInterface(UserInterfaceBase):
 
         self.add_pending_action(OpaqueCoroutine(coroutine=self.run_tk))
 
+    def spin_once(self):
+        if self.close_requested:
+            self.closing = True
+        self.root.update()
+
     async def run_tk(self, *args, **kwargs):
         while not self.closing:
-            self.root.update()
+            self.spin_once()
             await asyncio.sleep(0.05)
         self.root.destroy()
 

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -1,5 +1,5 @@
 #import pytest
-from ros2launch_gui.qt.process_output_widget import ansi_to_html
+from ros2launch_gui.ansi import ansi_to_html
 
 def test_plain_text_to_html():
     input = "my text"

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -29,3 +29,51 @@ def test_italic_colored_text_to_html():
     input = "\033[3;34mmy text\033[0m"
     expected = '<span style="color: #0000FF"><i>my text</i></span>'
     assert ansi_to_html(input) == expected
+
+def test_multi_segment_line():
+    """Multiple color regions on one line (typical ROS 2 output)."""
+    input = "\033[32m[INFO]\033[0m \033[36m[node]\033[0m: msg"
+    expected = (
+        '<span style="color: #00FF00">[INFO]</span>'
+        ' '
+        '<span style="color: #00FFFF">[node]</span>'
+        ': msg'
+    )
+    assert ansi_to_html(input) == expected
+
+def test_mid_line_color_change_no_reset():
+    """Color changes mid-line without reset in between."""
+    input = "\033[31mred\033[32mgreen\033[0m"
+    expected = (
+        '<span style="color: #FF0000">red</span>'
+        '<span style="color: #00FF00">green</span>'
+    )
+    assert ansi_to_html(input) == expected
+
+def test_only_reset_codes():
+    """Reset codes around plain text produce unstyled output."""
+    input = "\033[0mplain text\033[0m"
+    expected = 'plain text'
+    assert ansi_to_html(input) == expected
+
+def test_unknown_256_color_code():
+    """Unknown 256-color code is stripped; text rendered without styling."""
+    input = "\033[38;5;196mtext\033[0m"
+    expected = 'text'
+    assert ansi_to_html(input) == expected
+
+def test_consecutive_resets():
+    """Multiple consecutive resets before text."""
+    input = "\033[0m\033[0mtext"
+    expected = 'text'
+    assert ansi_to_html(input) == expected
+
+def test_modifier_with_multi_segment():
+    """Modifiers combined with colors across multiple segments."""
+    input = "\033[1;31mbold red\033[0m normal \033[4;34munderline blue\033[0m"
+    expected = (
+        '<span style="color: #FF0000"><b>bold red</b></span>'
+        ' normal '
+        '<span style="color: #0000FF"><u>underline blue</u></span>'
+    )
+    assert ansi_to_html(input) == expected


### PR DESCRIPTION
## Summary

This PR combines several related improvements to the ros2launch_gui package:

### Lazy Qt imports + ANSI extraction (issue #11)
- Lazy-import the Qt backend so the package can be imported without Qt installed (enables headless CI, tk-only environments)
- Extract `ansi_to_html` into a standalone utility module with full test coverage

### Multi-segment ANSI parsing (issue #21)
- Support lines with multiple ANSI color segments (e.g., `\033[31mred\033[0m normal \033[32mgreen\033[0m`)
- 12 unit tests covering plain text, single-color, multi-segment, modifiers, edge cases

### Simple/detailed tree view toggle
- Add a "Show Detailed Configuration" checkbox to the Qt launch tree
- Simple view shows only Nodes and LifecycleNodes; detailed view shows the full entity tree with conditions and launch arguments

### Event loop refactoring
- Add `spin_once()` to the base `UserInterface` class with overrides in both Qt and tk backends
- Add configurable `update_rate` parameter to the event handler
- Refactor `run_tk` to use `spin_once()` for consistency with the Qt backend
- Improve color semantics: running processes (light green), successful exit (light green), error exit (red), lifecycle states (yellow/green)

### Code quality
- Fix PEP 8 style (`if debug:` instead of `if(debug):`)
- Restore success-exit color to light green `(200, 255, 200)` — was accidentally set to brownish `(150, 100, 100)`

## Test plan
- [x] All 12 `test_ansi_to_html.py` tests pass
- [x] PEP 8 fix verified: no `if(debug)` pattern in codebase
- [x] Success-exit color restored to `QColor(200, 255, 200)`
- [x] tk backend has `spin_once()` override
- [ ] Manual test: launch a ROS 2 system with Qt GUI, verify tree views and process colors
- [ ] Manual test: launch with tk GUI, verify event loop works correctly

Closes #11
Closes #21

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
