### PR TITLE
fix: consolidate dual polling loops into single event-driven mechanism

### DIFF
--- a/ros2launch_gui/api/user_interface.py
+++ b/ros2launch_gui/api/user_interface.py
@@ -46,7 +46,7 @@ class UserInterface:
         self._debug = debug
         self._close_requested = False
 
-        update_rate = 1.0 if debug else 5.0
+        update_rate = 5.0 if debug else 20.0
         period = 1.0 / update_rate
 
         self._pending_actions = [

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -1,15 +1,10 @@
-import asyncio
-
 from python_qt_binding.QtWidgets import QApplication
 from python_qt_binding.QtWidgets import QMainWindow
 from python_qt_binding.QtWidgets import QSplitter
 
+from launch import LaunchDescription
 
 from ..api import UserInterface as UserInterfaceBase
-
-from launch import LaunchDescription
-from launch.actions import OpaqueCoroutine
-
 from .details_widget import DetailsWidget
 from .launch_description_widget import LaunchDescriptionWidget
 
@@ -56,34 +51,26 @@ class MainWindow(QMainWindow):
             self._ui.on_close()
         event.accept()
 
+
 class UserInterface(UserInterfaceBase):
     def __init__(
             self,
             launch_description: LaunchDescription,
             debug: bool = False,
-           
     ):
         super().__init__(launch_description, debug)
-
-        self.closing = False
 
         self.app = QApplication([])
         self.main_window = MainWindow(self)
         self.main_window.resize(1280, 720)
         self.main_window.show()
 
-        self.add_pending_action(OpaqueCoroutine(coroutine=self.run_qt))
-
-    async def run_qt(self, *args, **kwargs):
-        while not self.closing:
-            self.spin_once()
-            await asyncio.sleep(0.05)
-
     def spin_once(self):
-        if self.close_requested:
-            self.main_window.close()
         self.app.processEvents()
 
+    def close(self):
+        super().close()
+        self.main_window.close()
 
     def on_process_started(self, process_name, pid, action):
         self.main_window.on_process_started(action, process_name, pid)
@@ -104,6 +91,4 @@ class UserInterface(UserInterfaceBase):
         self.main_window.on_state_transition(entity, start_state, goal_state)
 
     def on_close(self):
-        self.closing = True
         super().on_close()
-        

--- a/ros2launch_gui/tk/user_interface.py
+++ b/ros2launch_gui/tk/user_interface.py
@@ -1,16 +1,13 @@
-
-import asyncio
-
 from tkinter import Tk
 from tkinter import ttk
 
 from launch import LaunchDescription
-from launch.actions import OpaqueCoroutine
 
 from ..api import DescribedLaunchEntity
 from ..api import UserInterface as UserInterfaceBase
 from .launch_description_treeview import LaunchDescriptionTreeview
 from .process_manager import ProcessManager
+
 
 class UserInterface(UserInterfaceBase):
     def __init__(
@@ -24,7 +21,6 @@ class UserInterface(UserInterfaceBase):
         self.root.grid_rowconfigure(0, weight=1)
         self.root.grid_columnconfigure(0, weight=1)
 
-        self.closing = False
         self.root.protocol("WM_DELETE_WINDOW", self.on_close)
 
         main_window = ttk.PanedWindow(self.root, orient='horizontal')
@@ -38,40 +34,35 @@ class UserInterface(UserInterfaceBase):
         self.process_manager = ProcessManager(main_window)
         main_window.add(self.process_manager, weight=1)
 
-        self.launch_description_viewer.add_process_selected_callback(self.process_manager.on_select_process)
+        self.launch_description_viewer.add_process_selected_callback(
+            self.process_manager.on_select_process)
 
-        self.add_pending_action(OpaqueCoroutine(coroutine=self.run_tk))
+    def spin_once(self):
+        self.root.update()
 
-    async def run_tk(self, *args, **kwargs):
-        while not self.closing:
-            self.root.update()
-            await asyncio.sleep(0.05)
+    def close(self):
+        super().close()
         self.root.destroy()
 
     def on_process_started(self, process_name, pid, action: DescribedLaunchEntity):
-        if not self.closing:
-            self.process_manager.on_process_started(process_name, pid, action)
-            self.launch_description_viewer.on_entity_process_started(action, process_name, pid)
+        self.process_manager.on_process_started(process_name, pid, action)
+        self.launch_description_viewer.on_entity_process_started(
+            action, process_name, pid)
 
     def on_process_exited(self, process_name, pid, action, return_code):
-        if not self.closing:
-            self.process_manager.on_process_exited(process_name, pid, action, return_code)
-            self.launch_description_viewer.on_entity_process_exited(action, process_name, pid, return_code)
+        self.process_manager.on_process_exited(
+            process_name, pid, action, return_code)
+        self.launch_description_viewer.on_entity_process_exited(
+            action, process_name, pid, return_code)
 
     def on_process_io(self, process_name, text):
-        if not self.closing:
-            self.process_manager.on_process_io(process_name, text.decode())
+        self.process_manager.on_process_io(process_name, text.decode())
 
     def on_describe_launch_entity(self, entity):
-        if not self.closing:
-            self.launch_description_viewer.on_describe_launch_entity(entity)
+        self.launch_description_viewer.on_describe_launch_entity(entity)
 
     def on_execution_complete(self, entity):
-        if not self.closing:
-            self.launch_description_viewer.on_execution_complete(entity)
+        self.launch_description_viewer.on_execution_complete(entity)
 
     def on_close(self):
-        self.closing = True
         super().on_close()
-
-


### PR DESCRIPTION
## Summary

Consolidates two independent, uncoordinated polling loops into a single event-driven mechanism, fixing several issues:

- **Removed `OpaqueCoroutine`** from both Qt and Tk backends — GUI processing is now driven solely through the `OnQueryUserInterface` timer chain
- **Increased timer rate** from 5Hz (200ms) to 20Hz (50ms), matching the old coroutine's cadence and reducing action latency from 200ms to 50ms
- **Fixed Tk `spin_once()` bug** — the Tk backend never overrode `spin_once()`, so calls from `OnQueryUserInterface` raised `NotImplementedError`
- **Removed redundant `closing` flag** and `if not self.closing` guards — these are now handled by `_safe_callback` (#18) and the `close_requested` check in `OnQueryUserInterface`

### Key insight

`OpaqueCoroutine.execute()` returns `None`, so the timer chain was already the sole path for pending actions to reach the launch system. The coroutine was purely redundant GUI processing.

### Backend contract (after change)

Each backend implements just two methods:
- `spin_once()` — process GUI events (`app.processEvents()` / `root.update()`)
- `close()` — destroy the window/root (after `super().close()` sets `_close_requested`)

### Files changed

| File | Change |
|------|--------|
| `api/user_interface.py` | Update rate: 5Hz/1Hz → 20Hz/5Hz |
| `qt/main.py` | Remove `OpaqueCoroutine`, `closing`, `run_qt()`; add `close()`; simplify `spin_once()` and `on_close()` |
| `tk/user_interface.py` | Remove `OpaqueCoroutine`, `closing`, `run_tk()`; add `spin_once()` + `close()`; remove `if not self.closing` guards; simplify `on_close()` |

## Test plan

- [x] Build: `colcon build --packages-select ros2launch_gui` — passes
- [x] No `OpaqueCoroutine` references remain: `grep -r OpaqueCoroutine` — no matches
- [x] Lint: `flake8 --max-line-length 99` — no new warnings (pre-existing only)
- [x] Smoke test (Qt): `ros2 launch -g turtlesim multisim.launch.py` — GUI displays, processes appear, output streams, clean shutdown via window close

Closes #17

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
