### PR TITLE
[PLAN] feat: add terminal UI (TUI) backend using urwid

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-16.md
+++ b/.agent/work-plans/PLAN_ISSUE-16.md
@@ -1,0 +1,125 @@
+# Plan: feat: add terminal UI (TUI) backend using urwid
+
+## Issue
+
+https://github.com/rolker/ros2launch_gui/issues/16
+
+## Context
+
+The existing `--gui` (`GuiOption`) and `--tk` backends require a display server. This
+plan adds a `--tui` flag that launches a urwid-based terminal UI for headless/SSH
+environments. The base class API (`UserInterface`), the `OptionExtension` entry-point
+pattern, the `DisplayUserInterface` action with its `ui_launcher` parameter, and the
+`OnQueryUserInterface` timer-driven `spin_once()` loop are all already in place — this
+backend slots in with no base-class changes.
+
+`rosdep resolve python3-urwid` → `#apt python3-urwid` (confirmed on Noble/Jazzy).
+
+## Approach
+
+### v1a — Core infrastructure (this PR)
+
+1. **`ros2launch_gui/tui/__init__.py`** — Lazy import (PEP 562), matching `tk/__init__.py`.
+
+2. **`ros2launch_gui/tui/user_interface.py`** — `UserInterface` subclass.
+   - `__init__`: create `urwid.MainLoop(top_widget)`, call `self.loop.screen.start()`.
+   - `spin_once()`: call `self.loop.screen.get_input_nonblocking()`, pass keys to
+     `self.loop.process_input()`, then `self.loop.draw_screen()`. Check `close_requested`
+     first. Called at 20 Hz by the existing `OnQueryUserInterface` timer — no async
+     coroutine or event-loop takeover needed.
+   - `close()`: call `super().close()` then `self.loop.screen.stop()`.
+   - `on_close()`: call `super().on_close()` (triggers `Shutdown()`).
+   - Implement all `on_process_*` / `on_state_transition()` callbacks to update widgets.
+
+3. **`ros2launch_gui/tui/process_list.py`** — urwid `ListBox` showing processes with
+   status indicators (RUNNING ●, EXITED ○, CRASHED ✗). Each row has a letter shortcut
+   (`[a]`, `[b]`, …). Arrow keys move selection; ENTER selects for single-output view.
+
+4. **`ros2launch_gui/tui/output_view.py`** — urwid `ListBox` for log output.
+   - All-processes mode (default): interleaved output with `[name]` prefix.
+   - Single-select mode: output from selected process only.
+   - Scrollback cap: 10,000 lines/process, 50,000 lines total (constants, easy to
+     change). Oldest lines discarded at limit — critical for long sessions.
+
+5. **`ros2launch_gui/tui/status_bar.py`** — `urwid.Text` row with keybinding hints.
+   Shows `[k]ill  [m]ute  [q]uit  [SPACE] toggle output  Lifecycle: [C]onfigure [A]ctivate [D]eactivate [S]hutdown`.
+
+6. **`ros2launch_gui/option/tui.py`** — `TuiOption(OptionExtension)`.
+   - `add_arguments`: adds `-t` / `--tui` flag.
+   - `prelaunch`: if `args.tui`, returns
+     `LaunchDescription([DisplayUserInterface(launch_description=ld, ui_launcher=_tui_launcher, debug=args.debug)])`.
+   - `_tui_launcher(ld, ctx, debug)` is a module-level factory — lazy-imports
+     `ros2launch_gui.tui.UserInterface` to avoid urwid import at flag registration time.
+   - If both `--gui` and `--tui` are passed: since each `OptionExtension.prelaunch` runs
+     independently and returns its own launch description, both would attempt to start.
+     Add a guard in `TuiOption.prelaunch` that checks `hasattr(args, 'gui') and args.gui`
+     and raises `ValueError('--tui and --gui are mutually exclusive')`.
+
+7. **`setup.py`** — add `'tui = ros2launch_gui.option.tui:TuiOption'` to
+   `ros2launch.option` entry points.
+
+8. **`package.xml`** — add `<depend>python3-urwid</depend>` (runtime dep, not test-only).
+
+### v1b — Interactive controls (follow-up PR, separate issue)
+
+- Lifecycle node state display (`[unconfigured]`, `[inactive]`, `[active]`) and keyboard
+  transitions via `EmitEvent(ChangeState(...))` through `add_pending_action()`.
+- Collapsible launch description tree using urwid `TreeWidget` / `ParentNode`.
+- Per-process muting (`[m]` key).
+- Kill process (`[k]` key via `ShutdownProcess` / `EmitEvent`).
+
+Splitting v1b into a follow-up PR keeps v1a reviewable and ships the core use case
+(headless monitoring) without blocking on the more complex keyboard interaction work.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `ros2launch_gui/tui/__init__.py` | New — lazy import |
+| `ros2launch_gui/tui/user_interface.py` | New — urwid `UserInterface` subclass |
+| `ros2launch_gui/tui/process_list.py` | New — process list widget |
+| `ros2launch_gui/tui/output_view.py` | New — output view with scrollback cap |
+| `ros2launch_gui/tui/status_bar.py` | New — keybinding hint bar |
+| `ros2launch_gui/option/tui.py` | New — `TuiOption` entry point |
+| `setup.py` | Add `tui` to `ros2launch.option` entry points |
+| `package.xml` | Add `<depend>python3-urwid</depend>` |
+| `test/test_tui_interface.py` | New — smoke test: `UserInterface.__init__` with mock screen |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | `--tui` is explicit opt-in; scrollback configurable; `[q]` quit always visible |
+| Only what's needed | v1a delivers the core use case; lifecycle/composition deferred to v1b |
+| Improve incrementally | v1a → v1b → v2 staged; no big-bang delivery |
+| A change includes its consequences | Smoke test included; `package.xml` dep added; `--gui`/`--tui` conflict handled |
+| Capture decisions | ADR for library choice recommended (see Open Questions) |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 | Yes | urwid library selection and event-loop integration are worth an ADR |
+| ADR-0002 | Yes | Worktree on `feature/issue-16` (already created) |
+| ADR-0008 | Yes | `python3-urwid` rosdep key verified (`#apt python3-urwid`) |
+| ADR-0009 | Yes | Runtime dep uses apt/rosdep, not `.venv` |
+
+## Consequences
+
+| If we change… | Also update… | Included? |
+|---|---|---|
+| Add `tui` entry point | `setup.py` + `package.xml` | Yes |
+| Both `--gui` and `--tui` flags exist | Document mutual exclusion | Yes (guard in `TuiOption`) |
+| New TUI files | `ament_flake8` / `ament_pep257` will lint them automatically | Yes (same test suite) |
+| No `.agents/README.md` exists | Should be created — but that's a separate task | No — follow-up |
+
+## Open Questions
+
+- Should the urwid library selection be captured as an ADR in this repo's `docs/decisions/`?
+  The rationale in the issue (urwid vs textual vs rich) is thorough. Recommend yes, but
+  can be deferred to v1b.
+
+## Estimated Scope
+
+Two PRs: v1a (this plan, core infrastructure) is a single focused PR. v1b (interactive
+controls) will be a follow-up issue.

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>Apache-2.0</license>
 
   <depend>python_qt_binding</depend>
+  <depend>python3-urwid</depend>
   <depend>ros2launch</depend>
 
   <exec_depend>launch</exec_depend>

--- a/ros2launch_gui/option/tui.py
+++ b/ros2launch_gui/option/tui.py
@@ -1,0 +1,41 @@
+from typing import Tuple
+
+from launch import LaunchDescription
+
+from ros2launch.option import OptionExtension
+from ros2launch_gui.actions import DisplayUserInterface
+
+
+def _create_tui(launch_description, context, debug):
+    from ros2launch_gui.tui import UserInterface
+    return UserInterface(launch_description, debug)
+
+
+class TuiOption(OptionExtension):
+
+    def add_arguments(self, parser, cli_name, *, argv=None):
+        parser.add_argument(
+            '-t', '--tui',
+            action='store_true',
+            help='Display launch status in a terminal UI'
+        )
+
+    def prelaunch(
+        self,
+        launch_description: LaunchDescription,
+        args
+    ) -> Tuple[LaunchDescription,]:
+        if args.tui:
+            if hasattr(args, 'gui') and args.gui:
+                raise ValueError(
+                    '--tui and --gui are mutually exclusive')
+            return LaunchDescription(
+                [
+                    DisplayUserInterface(
+                        launch_description=launch_description,
+                        ui_launcher=_create_tui,
+                        debug=args.debug),
+                ]
+            ),
+
+        return launch_description,

--- a/ros2launch_gui/tui/__init__.py
+++ b/ros2launch_gui/tui/__init__.py
@@ -1,0 +1,8 @@
+__all__ = ['UserInterface']
+
+
+def __getattr__(name):
+    if name == 'UserInterface':
+        from .user_interface import UserInterface
+        return UserInterface
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/ros2launch_gui/tui/output_view.py
+++ b/ros2launch_gui/tui/output_view.py
@@ -1,0 +1,56 @@
+import collections
+
+import urwid
+
+
+class OutputView(urwid.ListBox):
+    """Log output view with per-process and total scrollback caps."""
+
+    MAX_TOTAL_LINES = 50000
+    MAX_PER_PROCESS = 10000
+
+    def __init__(self):
+        self._walker = urwid.SimpleFocusListWalker([])
+        super().__init__(self._walker)
+        self._all_lines = collections.deque(maxlen=self.MAX_TOTAL_LINES)
+        self._per_process = {}
+        self._filter = None
+
+    def add_line(self, process_name, text):
+        """Append a line of output, respecting the current filter."""
+        entry = (process_name, text)
+        self._all_lines.append(entry)
+
+        if process_name not in self._per_process:
+            self._per_process[process_name] = collections.deque(
+                maxlen=self.MAX_PER_PROCESS)
+        self._per_process[process_name].append(text)
+
+        if self._filter is None or self._filter == process_name:
+            self._append_widget(process_name, text)
+
+    def apply_filter(self, process_name):
+        """Switch output filter and rebuild the view."""
+        self._filter = process_name
+        del self._walker[:]
+        if process_name is None:
+            for name, text in self._all_lines:
+                self._walker.append(self._make_widget(name, text))
+        elif process_name in self._per_process:
+            for text in self._per_process[process_name]:
+                self._walker.append(
+                    self._make_widget(process_name, text))
+        self._scroll_to_bottom()
+
+    def _append_widget(self, name, text):
+        self._walker.append(self._make_widget(name, text))
+        while len(self._walker) > self.MAX_TOTAL_LINES:
+            del self._walker[0]
+        self._scroll_to_bottom()
+
+    def _make_widget(self, name, text):
+        return urwid.Text([('prefix', f'[{name}] '), text])
+
+    def _scroll_to_bottom(self):
+        if self._walker:
+            self._walker.set_focus(len(self._walker) - 1)

--- a/ros2launch_gui/tui/output_view.py
+++ b/ros2launch_gui/tui/output_view.py
@@ -4,7 +4,13 @@ import urwid
 
 
 class OutputView(urwid.ListBox):
-    """Log output view with per-process and total scrollback caps."""
+    """Log output view with per-process and total scrollback caps.
+
+    Lines are stored in both a global deque and per-process deques so that
+    filter switching is O(1) rebuild from the relevant deque.  Total memory
+    may exceed MAX_TOTAL_LINES when many processes are active (bounded by
+    MAX_TOTAL_LINES + num_processes * MAX_PER_PROCESS).
+    """
 
     MAX_TOTAL_LINES = 50000
     MAX_PER_PROCESS = 10000

--- a/ros2launch_gui/tui/output_view.py
+++ b/ros2launch_gui/tui/output_view.py
@@ -44,7 +44,8 @@ class OutputView(urwid.ListBox):
 
     def _append_widget(self, name, text):
         self._walker.append(self._make_widget(name, text))
-        while len(self._walker) > self.MAX_TOTAL_LINES:
+        cap = self.MAX_PER_PROCESS if self._filter else self.MAX_TOTAL_LINES
+        while len(self._walker) > cap:
             del self._walker[0]
         self._scroll_to_bottom()
 

--- a/ros2launch_gui/tui/output_view.py
+++ b/ros2launch_gui/tui/output_view.py
@@ -6,8 +6,9 @@ import urwid
 class OutputView(urwid.ListBox):
     """Log output view with per-process and total scrollback caps.
 
-    Lines are stored in both a global deque and per-process deques so that
-    filter switching is O(1) rebuild from the relevant deque.  Total memory
+    Lines are stored in both a global deque and per-process deques.  Selecting
+    the backing deque for a given filter is O(1), and rebuilding the visible
+    list from that deque is O(n) in the number of buffered lines.  Total memory
     may exceed MAX_TOTAL_LINES when many processes are active (bounded by
     MAX_TOTAL_LINES + num_processes * MAX_PER_PROCESS).
     """

--- a/ros2launch_gui/tui/process_list.py
+++ b/ros2launch_gui/tui/process_list.py
@@ -1,0 +1,66 @@
+import urwid
+
+
+class ProcessListItem(urwid.WidgetWrap):
+    """A single process entry in the process list."""
+
+    RUNNING = ('running', '\u25cf RUNNING')
+    EXITED = ('exited', '\u25cb EXITED')
+    CRASHED = ('crashed', '\u2717 CRASHED')
+
+    def __init__(self, shortcut, name, pid):
+        self.process_name = name
+        self.pid = pid
+        self._status = self.RUNNING
+
+        self._status_widget = urwid.Text(self._status)
+        cols = urwid.Columns([
+            ('fixed', 4, urwid.Text(f'[{shortcut}]')),
+            ('weight', 1, urwid.Text(name)),
+            ('fixed', 12, self._status_widget),
+            ('fixed', 12, urwid.Text(f'pid:{pid}')),
+        ], dividechars=1)
+        super().__init__(urwid.AttrMap(cols, None, focus_map='focused'))
+
+    def update_status(self, return_code):
+        if return_code == 0:
+            self._status = self.EXITED
+        else:
+            self._status = self.CRASHED
+        self._status_widget.set_text(self._status)
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+
+class ProcessList(urwid.ListBox):
+    """Scrollable list of launched processes with status indicators."""
+
+    def __init__(self):
+        self._walker = urwid.SimpleFocusListWalker([])
+        self._items = {}
+        self._next_shortcut = ord('a')
+        super().__init__(self._walker)
+
+    def add_process(self, name, pid):
+        shortcut = chr(self._next_shortcut) \
+            if self._next_shortcut <= ord('z') else '?'
+        if self._next_shortcut <= ord('z'):
+            self._next_shortcut += 1
+        item = ProcessListItem(shortcut, name, pid)
+        self._items[name] = item
+        self._walker.append(item)
+
+    def update_process_status(self, name, return_code):
+        if name in self._items:
+            self._items[name].update_status(return_code)
+
+    def get_focused_process(self):
+        if self._walker:
+            widget, _ = self._walker.get_focus()
+            if widget is not None and hasattr(widget, 'process_name'):
+                return widget.process_name
+        return None

--- a/ros2launch_gui/tui/process_list.py
+++ b/ros2launch_gui/tui/process_list.py
@@ -14,11 +14,12 @@ class ProcessListItem(urwid.WidgetWrap):
         self._status = self.RUNNING
 
         self._status_widget = urwid.Text(self._status)
+        self._pid_widget = urwid.Text(f'pid:{pid}')
         cols = urwid.Columns([
             ('fixed', 4, urwid.Text(f'[{shortcut}]')),
             ('weight', 1, urwid.Text(name)),
             ('fixed', 12, self._status_widget),
-            ('fixed', 12, urwid.Text(f'pid:{pid}')),
+            ('fixed', 12, self._pid_widget),
         ], dividechars=1)
         super().__init__(urwid.AttrMap(cols, None, focus_map='focused'))
 
@@ -49,6 +50,7 @@ class ProcessList(urwid.ListBox):
         if name in self._items:
             existing = self._items[name]
             existing.pid = pid
+            existing._pid_widget.set_text(f'pid:{pid}')
             existing._status = ProcessListItem.RUNNING
             existing._status_widget.set_text(existing._status)
             return

--- a/ros2launch_gui/tui/process_list.py
+++ b/ros2launch_gui/tui/process_list.py
@@ -46,6 +46,12 @@ class ProcessList(urwid.ListBox):
         super().__init__(self._walker)
 
     def add_process(self, name, pid):
+        if name in self._items:
+            existing = self._items[name]
+            existing.pid = pid
+            existing._status = ProcessListItem.RUNNING
+            existing._status_widget.set_text(existing._status)
+            return
         shortcut = chr(self._next_shortcut) \
             if self._next_shortcut <= ord('z') else '?'
         if self._next_shortcut <= ord('z'):

--- a/ros2launch_gui/tui/status_bar.py
+++ b/ros2launch_gui/tui/status_bar.py
@@ -1,0 +1,10 @@
+import urwid
+
+
+class StatusBar(urwid.Text):
+    """Bottom bar showing keybinding hints."""
+
+    def __init__(self):
+        super().__init__(
+            ' [q]uit  [Enter] select process  '
+            '[Up/Down] navigate')

--- a/ros2launch_gui/tui/user_interface.py
+++ b/ros2launch_gui/tui/user_interface.py
@@ -68,10 +68,10 @@ class UserInterface(UserInterfaceBase):
     def spin_once(self):
         if self.close_requested:
             return
-        self.loop.draw_screen()
         keys = self.screen.get_input()
         for key in keys:
             self.loop.process_input([key])
+        self.loop.draw_screen()
 
     def close(self):
         super().close()
@@ -89,7 +89,7 @@ class UserInterface(UserInterfaceBase):
             process_name, return_code)
 
     def on_process_io(self, process_name, text):
-        decoded = text.decode() if isinstance(text, bytes) else text
+        decoded = text.decode(errors='replace') if isinstance(text, bytes) else text
         clean = _ANSI_RE.sub('', decoded)
         for line in clean.splitlines():
             self.output_view.add_line(process_name, line)

--- a/ros2launch_gui/tui/user_interface.py
+++ b/ros2launch_gui/tui/user_interface.py
@@ -1,0 +1,113 @@
+import re
+
+from launch import LaunchDescription
+
+import urwid
+
+from .output_view import OutputView
+from .process_list import ProcessList
+from .status_bar import StatusBar
+from ..api import DescribedLaunchEntity
+from ..api import UserInterface as UserInterfaceBase
+
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')
+
+PALETTE = [
+    ('running', 'light green', ''),
+    ('exited', 'light gray', ''),
+    ('crashed', 'light red', ''),
+    ('focused', 'black', 'light gray'),
+    ('header', 'white,bold', 'dark blue'),
+    ('status_bar', 'white', 'dark blue'),
+    ('prefix', 'light cyan', ''),
+]
+
+
+class UserInterface(UserInterfaceBase):
+    def __init__(
+            self,
+            launch_description: LaunchDescription,
+            debug: bool = False
+    ):
+        super().__init__(launch_description, debug)
+
+        self.process_list = ProcessList()
+        self.output_view = OutputView()
+        self.status_bar = StatusBar()
+
+        process_header = urwid.AttrMap(
+            urwid.Text(' Processes'), 'header')
+        self._output_header_text = urwid.Text(' Output (all)')
+        output_header = urwid.AttrMap(
+            self._output_header_text, 'header')
+
+        body = urwid.Pile([
+            ('pack', process_header),
+            ('weight', 1, self.process_list),
+            ('pack', output_header),
+            ('weight', 3, self.output_view),
+        ])
+
+        frame = urwid.Frame(
+            body=body,
+            footer=urwid.AttrMap(self.status_bar, 'status_bar'),
+        )
+
+        self.screen = urwid.raw_display.Screen()
+        self.loop = urwid.MainLoop(
+            frame,
+            palette=PALETTE,
+            screen=self.screen,
+            unhandled_input=self._handle_input,
+        )
+        self.loop.start()
+        self.screen.set_input_timeouts(max_wait=0)
+
+        self._output_filter = None
+
+    def spin_once(self):
+        if self.close_requested:
+            return
+        self.loop.draw_screen()
+        keys = self.screen.get_input()
+        for key in keys:
+            self.loop.process_input([key])
+
+    def close(self):
+        super().close()
+        try:
+            self.loop.stop()
+        except Exception:
+            pass
+
+    def on_process_started(self, process_name, pid,
+                           action: DescribedLaunchEntity):
+        self.process_list.add_process(process_name, pid)
+
+    def on_process_exited(self, process_name, pid, action, return_code):
+        self.process_list.update_process_status(
+            process_name, return_code)
+
+    def on_process_io(self, process_name, text):
+        decoded = text.decode() if isinstance(text, bytes) else text
+        clean = _ANSI_RE.sub('', decoded)
+        for line in clean.splitlines():
+            self.output_view.add_line(process_name, line)
+
+    def on_close(self):
+        super().on_close()
+
+    def _handle_input(self, key):
+        if key in ('q', 'Q'):
+            self.on_close()
+        elif key == 'enter':
+            name = self.process_list.get_focused_process()
+            if name is not None:
+                if self._output_filter == name:
+                    self._output_filter = None
+                    self._output_header_text.set_text(' Output (all)')
+                else:
+                    self._output_filter = name
+                    self._output_header_text.set_text(
+                        f' Output ({name})')
+                self.output_view.apply_filter(self._output_filter)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'ros2launch.option': [
           'gui = ros2launch_gui.option.gui:GuiOption',
+          'tui = ros2launch_gui.option.tui:TuiOption',
         ],
     },
 )

--- a/test/test_tui_interface.py
+++ b/test/test_tui_interface.py
@@ -87,6 +87,52 @@ class TestTuiUserInterface(unittest.TestCase):
 
         ui.close()
 
+    @patch('urwid.MainLoop')
+    @patch('urwid.raw_display.Screen')
+    def test_process_respawn_reuses_row(self, mock_screen_cls, mock_loop_cls):
+        mock_screen_cls.return_value = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop_cls.return_value = mock_loop
+        mock_loop.screen = mock_screen_cls.return_value
+
+        from ros2launch_gui.tui.user_interface import UserInterface
+
+        ld = LaunchDescription()
+        ui = UserInterface(ld)
+
+        action = MagicMock()
+        ui.on_process_started('node_a', 100, action)
+        ui.on_process_exited('node_a', 100, action, 1)
+        # Respawn with new pid
+        ui.on_process_started('node_a', 200, action)
+
+        assert len(ui.process_list._walker) == 1
+        item = ui.process_list._items['node_a']
+        assert item.pid == 200
+        assert item._status == item.RUNNING
+
+        ui.close()
+
+    @patch('urwid.MainLoop')
+    @patch('urwid.raw_display.Screen')
+    def test_filtered_scrollback_cap(self, mock_screen_cls, mock_loop_cls):
+        mock_screen_cls.return_value = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop_cls.return_value = mock_loop
+        mock_loop.screen = mock_screen_cls.return_value
+
+        from ros2launch_gui.tui.output_view import OutputView
+
+        view = OutputView()
+        view.MAX_PER_PROCESS = 5
+        view.MAX_TOTAL_LINES = 100
+        view._filter = 'node_a'
+
+        for i in range(10):
+            view.add_line('node_a', f'line {i}')
+
+        assert len(view._walker) == 5
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_tui_interface.py
+++ b/test/test_tui_interface.py
@@ -125,7 +125,6 @@ class TestTuiUserInterface(unittest.TestCase):
 
         view = OutputView()
         view.MAX_PER_PROCESS = 5
-        view.MAX_TOTAL_LINES = 100
         view._filter = 'node_a'
 
         for i in range(10):

--- a/test/test_tui_interface.py
+++ b/test/test_tui_interface.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from launch import LaunchDescription
+
+
+class TestTuiUserInterface(unittest.TestCase):
+    """Smoke tests for TUI backend initialisation."""
+
+    @patch('urwid.MainLoop')
+    @patch('urwid.raw_display.Screen')
+    def test_init_and_close(self, mock_screen_cls, mock_loop_cls):
+        mock_screen = MagicMock()
+        mock_screen_cls.return_value = mock_screen
+        mock_loop = MagicMock()
+        mock_loop_cls.return_value = mock_loop
+        mock_loop.screen = mock_screen
+
+        from ros2launch_gui.tui.user_interface import UserInterface
+
+        ld = LaunchDescription()
+        ui = UserInterface(ld)
+
+        assert not ui.close_requested
+        assert ui.process_list is not None
+        assert ui.output_view is not None
+
+        mock_loop.start.assert_called_once()
+
+        ui.close()
+        assert ui.close_requested
+        mock_loop.stop.assert_called_once()
+
+    @patch('urwid.MainLoop')
+    @patch('urwid.raw_display.Screen')
+    def test_process_lifecycle(self, mock_screen_cls, mock_loop_cls):
+        mock_screen_cls.return_value = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop_cls.return_value = mock_loop
+        mock_loop.screen = mock_screen_cls.return_value
+
+        from ros2launch_gui.tui.user_interface import UserInterface
+        from ros2launch_gui.api.describe import DescribedLaunchEntity
+
+        ld = LaunchDescription()
+        ui = UserInterface(ld)
+
+        action = MagicMock(spec=DescribedLaunchEntity)
+        ui.on_process_started('test_node', 1234, action)
+        assert 'test_node' in ui.process_list._items
+
+        ui.on_process_io('test_node', b'hello world\n')
+        assert len(ui.output_view._walker) == 1
+
+        ui.on_process_exited('test_node', 1234, action, 0)
+
+        ui.close()
+
+    @patch('urwid.MainLoop')
+    @patch('urwid.raw_display.Screen')
+    def test_output_filter_toggle(self, mock_screen_cls, mock_loop_cls):
+        mock_screen_cls.return_value = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop_cls.return_value = mock_loop
+        mock_loop.screen = mock_screen_cls.return_value
+
+        from ros2launch_gui.tui.user_interface import UserInterface
+
+        ld = LaunchDescription()
+        ui = UserInterface(ld)
+
+        action = MagicMock()
+        ui.on_process_started('node_a', 100, action)
+        ui.on_process_started('node_b', 101, action)
+        ui.on_process_io('node_a', b'line a\n')
+        ui.on_process_io('node_b', b'line b\n')
+
+        assert len(ui.output_view._walker) == 2
+
+        # Filter to node_a
+        ui.output_view.apply_filter('node_a')
+        assert len(ui.output_view._walker) == 1
+
+        # Back to all
+        ui.output_view.apply_filter(None)
+        assert len(ui.output_view._walker) == 2
+
+        ui.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #16

# Plan: feat: add terminal UI (TUI) backend using urwid

## Issue

https://github.com/rolker/ros2launch_gui/issues/16

## Context

The existing `--gui` (`GuiOption`) and `--tk` backends require a display server. This
plan adds a `--tui` flag that launches a urwid-based terminal UI for headless/SSH
environments. The base class API (`UserInterface`), the `OptionExtension` entry-point
pattern, the `DisplayUserInterface` action with its `ui_launcher` parameter, and the
`OnQueryUserInterface` timer-driven `spin_once()` loop are all already in place — this
backend slots in with no base-class changes.

`rosdep resolve python3-urwid` → `#apt python3-urwid` (confirmed on Noble/Jazzy).

## Approach

### v1a — Core infrastructure (this PR)

1. **`ros2launch_gui/tui/__init__.py`** — Lazy import (PEP 562), matching `tk/__init__.py`.

2. **`ros2launch_gui/tui/user_interface.py`** — `UserInterface` subclass.
   - `__init__`: create `urwid.MainLoop(top_widget)`, call `self.loop.screen.start()`.
   - `spin_once()`: call `self.loop.screen.get_input_nonblocking()`, pass keys to
     `self.loop.process_input()`, then `self.loop.draw_screen()`. Check `close_requested`
     first. Called at 20 Hz by the existing `OnQueryUserInterface` timer — no async
     coroutine or event-loop takeover needed.
   - `close()`: call `super().close()` then `self.loop.screen.stop()`.
   - `on_close()`: call `super().on_close()` (triggers `Shutdown()`).
   - Implement all `on_process_*` / `on_state_transition()` callbacks to update widgets.

3. **`ros2launch_gui/tui/process_list.py`** — urwid `ListBox` showing processes with
   status indicators (RUNNING ●, EXITED ○, CRASHED ✗). Each row has a letter shortcut
   (`[a]`, `[b]`, …). Arrow keys move selection; ENTER selects for single-output view.

4. **`ros2launch_gui/tui/output_view.py`** — urwid `ListBox` for log output.
   - All-processes mode (default): interleaved output with `[name]` prefix.
   - Single-select mode: output from selected process only.
   - Scrollback cap: 10,000 lines/process, 50,000 lines total (constants, easy to
     change). Oldest lines discarded at limit — critical for long sessions.

5. **`ros2launch_gui/tui/status_bar.py`** — `urwid.Text` row with keybinding hints.
   Shows `[k]ill  [m]ute  [q]uit  [SPACE] toggle output  Lifecycle: [C]onfigure [A]ctivate [D]eactivate [S]hutdown`.

6. **`ros2launch_gui/option/tui.py`** — `TuiOption(OptionExtension)`.
   - `add_arguments`: adds `-t` / `--tui` flag.
   - `prelaunch`: if `args.tui`, returns
     `LaunchDescription([DisplayUserInterface(launch_description=ld, ui_launcher=_tui_launcher, debug=args.debug)])`.
   - `_tui_launcher(ld, ctx, debug)` is a module-level factory — lazy-imports
     `ros2launch_gui.tui.UserInterface` to avoid urwid import at flag registration time.
   - If both `--gui` and `--tui` are passed: since each `OptionExtension.prelaunch` runs
     independently and returns its own launch description, both would attempt to start.
     Add a guard in `TuiOption.prelaunch` that checks `hasattr(args, 'gui') and args.gui`
     and raises `ValueError('--tui and --gui are mutually exclusive')`.

7. **`setup.py`** — add `'tui = ros2launch_gui.option.tui:TuiOption'` to
   `ros2launch.option` entry points.

8. **`package.xml`** — add `<depend>python3-urwid</depend>` (runtime dep, not test-only).

### v1b — Interactive controls (follow-up PR, separate issue)

- Lifecycle node state display (`[unconfigured]`, `[inactive]`, `[active]`) and keyboard
  transitions via `EmitEvent(ChangeState(...))` through `add_pending_action()`.
- Collapsible launch description tree using urwid `TreeWidget` / `ParentNode`.
- Per-process muting (`[m]` key).
- Kill process (`[k]` key via `ShutdownProcess` / `EmitEvent`).

Splitting v1b into a follow-up PR keeps v1a reviewable and ships the core use case
(headless monitoring) without blocking on the more complex keyboard interaction work.

## Files to Change

| File | Change |
|------|--------|
| `ros2launch_gui/tui/__init__.py` | New — lazy import |
| `ros2launch_gui/tui/user_interface.py` | New — urwid `UserInterface` subclass |
| `ros2launch_gui/tui/process_list.py` | New — process list widget |
| `ros2launch_gui/tui/output_view.py` | New — output view with scrollback cap |
| `ros2launch_gui/tui/status_bar.py` | New — keybinding hint bar |
| `ros2launch_gui/option/tui.py` | New — `TuiOption` entry point |
| `setup.py` | Add `tui` to `ros2launch.option` entry points |
| `package.xml` | Add `<depend>python3-urwid</depend>` |
| `test/test_tui_interface.py` | New — smoke test: `UserInterface.__init__` with mock screen |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | `--tui` is explicit opt-in; scrollback configurable; `[q]` quit always visible |
| Only what's needed | v1a delivers the core use case; lifecycle/composition deferred to v1b |
| Improve incrementally | v1a → v1b → v2 staged; no big-bang delivery |
| A change includes its consequences | Smoke test included; `package.xml` dep added; `--gui`/`--tui` conflict handled |
| Capture decisions | ADR for library choice recommended (see Open Questions) |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0001 | Yes | urwid library selection and event-loop integration are worth an ADR |
| ADR-0002 | Yes | Worktree on `feature/issue-16` (already created) |
| ADR-0008 | Yes | `python3-urwid` rosdep key verified (`#apt python3-urwid`) |
| ADR-0009 | Yes | Runtime dep uses apt/rosdep, not `.venv` |

## Consequences

| If we change… | Also update… | Included? |
|---|---|---|
| Add `tui` entry point | `setup.py` + `package.xml` | Yes |
| Both `--gui` and `--tui` flags exist | Document mutual exclusion | Yes (guard in `TuiOption`) |
| New TUI files | `ament_flake8` / `ament_pep257` will lint them automatically | Yes (same test suite) |
| No `.agents/README.md` exists | Should be created — but that's a separate task | No — follow-up |

## Open Questions

- Should the urwid library selection be captured as an ADR in this repo's `docs/decisions/`?
  The rationale in the issue (urwid vs textual vs rich) is thorough. Recommend yes, but
  can be deferred to v1b.

## Estimated Scope

Two PRs: v1a (this plan, core infrastructure) is a single focused PR. v1b (interactive
controls) will be a follow-up issue.
