### PR TITLE
Lint cleanup: make ament_flake8 / ament_pep257 green so the merge gate is reachable

### DIFF
--- a/.agent/work-plans/issue-31/progress.md
+++ b/.agent/work-plans/issue-31/progress.md
@@ -1,0 +1,84 @@
+---
+issue: 31
+---
+
+# Issue #31 — Lint cleanup: flake8 + pep257 to zero
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-23 23:17 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+Mechanical lint cleanup so `pytest test/` is green independently of any
+feature work. No behavioural change intended anywhere in the diff.
+
+### Before / after
+
+| Linter | Before | After |
+|---|---|---|
+| `ament_flake8` | 156 errors, 15 files | 0 (35 files checked) |
+| `ament_pep257` | 10 errors | 0 |
+
+Error classes fixed: E501 (31), Q000 (28), E302 (23), E303 (15), I100 (12),
+A001 (12), W293 (6), E252 (4), W391 (3), F841 (3), E251 (3), CNL100 (3),
+W291 (2), F401 (2), E713 (2), D205 (2), E275, E265, D400, D202.
+
+Nine atomic commits, one per error class: `a4cb4dd` Q000, `b454186` blank
+lines/whitespace, `07943d7` spacing + membership tests, `db92cc1` CNL100,
+`7528e2e` imports, `7438960` F841, `e994469` A001, `6c2235b` docstrings,
+`4efb03b` E501.
+
+### Judged rather than mechanically fixed
+
+**The three F841 unused exception bindings** (all in `api/describe.py`) —
+each `except Exception as e:` clause never referenced `e`, and each already
+substitutes a well-defined fallback, so the binding is genuinely dead and was
+removed (`except Exception:`) rather than used:
+
+- IncludeLaunchDescription child resolution -> `self.children = []`
+- launch-argument key/value description -> `str(la[0])` / `str(la[1])`
+
+**Flagged, not silently fixed**: the IncludeLaunchDescription handler swallows
+its failure with no diagnostic at all, while the sibling handler a few lines
+above surfaces `str(e)` as the entity description. A launch file that fails to
+resolve therefore renders as a childless node with no hint why. That asymmetry
+looks like a latent observability gap, but surfacing the error would be a
+behaviour change and is out of scope for a lint-only pass — it wants its own
+issue.
+
+**A001 (12)** — `input` shadowing the builtin in every test in
+`test/test_ansi_to_html.py`. Renamed the test-local to `text`; assertions
+unchanged. A rename, but confined to test locals and unavoidable for a clean
+run.
+
+**One docstring word changed** — the `ProcessManager` class docstring was 103
+columns. Reflowing it to a two-line summary tripped D205/D400, so "as well as"
+became "and", which fits the summary on one line at 97 columns. This is the
+only wording change in the diff.
+
+**`if(args.gui):`** (E275) — autopep8 produced `if (args.gui):`; the redundant
+parens were dropped for `if args.gui:`. Style-only.
+
+### Verification
+
+Method note: after the E501 pass, each changed file's Python token stream was
+compared against the previous revision with `tokenize`. The only non-whitespace
+deltas across all seven files were an added trailing comma inside a list
+literal, two grouping parentheses, and the one docstring word above —
+confirming the wrap is inert.
+
+```
+ament_flake8                           -> FLAKE8 CLEAN (0 errors, 35 files)
+ament_pep257                           -> PEP257 CLEAN
+./underlay_ws/build.sh ros2launch_gui  -> Finished <<< ros2launch_gui
+./underlay_ws/test.sh  ros2launch_gui  -> 20 tests, 0 errors, 0 failures, 1 skipped
+python3 -m pytest test/ -q             -> 19 passed, 1 skipped
+```
+
+The one skip is `test_copyright`, which carries a `@pytest.mark.skip` decorator
+on main and was not touched.
+
+Not pushed and no PR opened, per instruction — the host publishes after the
+operator checkpoint. This unblocks #30 (poll-loop handler leak), whose merge
+gate is a full-scope `ci_local.sh` attestation that cannot pass while lint is
+red.

--- a/ros2launch_gui/actions/display_user_interface.py
+++ b/ros2launch_gui/actions/display_user_interface.py
@@ -11,8 +11,10 @@ from launch import LaunchDescriptionEntity
 from ..api.create_default_user_interface import create_default_user_interface
 from ..api import UserInterface
 
+
 class DisplayUserInterface(Action):
     """Action to display a user interface for the launch system."""
+
     def __init__(
             self,
             *,

--- a/ros2launch_gui/actions/display_user_interface.py
+++ b/ros2launch_gui/actions/display_user_interface.py
@@ -24,8 +24,6 @@ class DisplayUserInterface(Action):
     ):
         """
         Create a DisplayUserInterface action.
-        
-        
 
         :param launch_description: The launch description to display the user interface for.
         :param ui_launcher: The function to use to create the user interface.

--- a/ros2launch_gui/actions/display_user_interface.py
+++ b/ros2launch_gui/actions/display_user_interface.py
@@ -19,7 +19,9 @@ class DisplayUserInterface(Action):
             self,
             *,
             launch_description: LaunchDescription,
-            ui_launcher: Callable[[LaunchDescription, LaunchContext, bool], UserInterface] = create_default_user_interface,
+            ui_launcher: Callable[
+                [LaunchDescription, LaunchContext, bool], UserInterface
+            ] = create_default_user_interface,
             debug: bool = False
     ):
         """

--- a/ros2launch_gui/actions/display_user_interface.py
+++ b/ros2launch_gui/actions/display_user_interface.py
@@ -8,8 +8,8 @@ from launch import LaunchContext
 from launch import LaunchDescription
 from launch import LaunchDescriptionEntity
 
-from ..api.create_default_user_interface import create_default_user_interface
 from ..api import UserInterface
+from ..api.create_default_user_interface import create_default_user_interface
 
 
 class DisplayUserInterface(Action):

--- a/ros2launch_gui/ansi.py
+++ b/ros2launch_gui/ansi.py
@@ -20,7 +20,8 @@ ansi_color_re = re.compile(r'\033\[([0-9;]*)m')
 
 
 def _parse_codes(codes):
-    """Parse ANSI code list into (modifier, color) tuple.
+    """
+    Parse ANSI code list into (modifier, color) tuple.
 
     Returns (modifier_tag, color_hex) where modifier_tag is 'b', 'i', 'u',
     or None, and color_hex is an HTML color string or None.
@@ -42,7 +43,8 @@ def _parse_codes(codes):
 
 
 def ansi_to_html(text):
-    """Convert ANSI color codes in text to HTML spans.
+    """
+    Convert ANSI color codes in text to HTML spans.
 
     Handles multiple color regions per line, mid-line color changes,
     reset codes, and modifier+color combinations.

--- a/ros2launch_gui/api/create_default_user_interface.py
+++ b/ros2launch_gui/api/create_default_user_interface.py
@@ -4,6 +4,7 @@ from launch import LaunchDescription
 
 from ros2launch_gui.api import UserInterface
 
+
 def create_default_user_interface(
         launch_description: LaunchDescription,
         context: LaunchContext,
@@ -14,4 +15,3 @@ def create_default_user_interface(
     from ros2launch_gui.qt import UserInterface
 
     return UserInterface(launch_description, debug=debug)
-

--- a/ros2launch_gui/api/create_default_user_interface.py
+++ b/ros2launch_gui/api/create_default_user_interface.py
@@ -11,7 +11,6 @@ def create_default_user_interface(
         debug: bool = False
 ) -> UserInterface:
     """Create a ui for monitoring launch events."""
-
     from ros2launch_gui.qt import UserInterface
 
     return UserInterface(launch_description, debug=debug)

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -59,7 +59,7 @@ class DescribedLaunchEntity:
         if isinstance(launch_entity, IncludeLaunchDescription):
             try:
                 self.children = [DescribedLaunchEntity(launch_entity.launch_description_source.get_launch_description(context)),]
-            except Exception as e:
+            except Exception:
                 self.children = []
         else:
             self.children = [DescribedLaunchEntity(child) for child in launch_entity.describe_sub_entities()]
@@ -77,11 +77,11 @@ class DescribedLaunchEntity:
             for la in launch_entity.launch_arguments:
                 try:
                     la0 = describe_substitution(la[0], context)
-                except Exception as e:
+                except Exception:
                     la0 = str(la[0])
                 try:
                     la1 = describe_substitution(la[1], context)
-                except Exception as e:
+                except Exception:
                     la1 = str(la[1])
                 self.launch_arguments.append((la0, la1))
 

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -105,7 +105,7 @@ class DescribedLaunchEntity:
                 self.label = launch_entity.node_name
             except RuntimeError:
                 pass
-            self.description = "package: {}, executable: {}".format(launch_entity.node_package, launch_entity.node_executable)
+            self.description = 'package: {}, executable: {}'.format(launch_entity.node_package, launch_entity.node_executable)
         
         elif isinstance(launch_entity, PushRosNamespace):
             self.label = describe_substitution(launch_entity.namespace, context)

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -106,16 +106,14 @@ class DescribedLaunchEntity:
             except RuntimeError:
                 pass
             self.description = 'package: {}, executable: {}'.format(launch_entity.node_package, launch_entity.node_executable)
-        
+
         elif isinstance(launch_entity, PushRosNamespace):
             self.label = describe_substitution(launch_entity.namespace, context)
             self.description = describe_substitution(launch_entity.namespace, None)
 
-
-
-
     def __repr__(self):
         return 'id: {} ({}) name: {} desc: {}'.format(self.id, self.type_name, self.label, self.description)
+
 
 def describe_condition(condition: Condition, context: LaunchContext) -> str:
     if condition is not None:
@@ -127,6 +125,7 @@ def describe_condition(condition: Condition, context: LaunchContext) -> str:
                 value = str(e)
         return '{}: {}'.format(type(condition).__name__, value)
     return ''
+
 
 def describe_substitution(substitution, context: LaunchContext) -> str:
     if substitution is None:

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -57,16 +57,23 @@ class DescribedLaunchEntity:
 
         self.conditional_children = []
 
-        # IncludeLaunchDescription's describe_sub_entities() method returns temporary entities with different ids than the entities actually run, so try to get the real ones.
+        # IncludeLaunchDescription's describe_sub_entities() method returns temporary
+        # entities with different ids than the entities actually run, so try to get
+        # the real ones.
         if isinstance(launch_entity, IncludeLaunchDescription):
             try:
-                self.children = [DescribedLaunchEntity(launch_entity.launch_description_source.get_launch_description(context)),]
+                self.children = [
+                    DescribedLaunchEntity(
+                        launch_entity.launch_description_source.get_launch_description(context)),
+                ]
             except Exception:
                 self.children = []
         else:
-            self.children = [DescribedLaunchEntity(child) for child in launch_entity.describe_sub_entities()]
+            self.children = [
+                DescribedLaunchEntity(child) for child in launch_entity.describe_sub_entities()]
             for condition, sub_entities in launch_entity.describe_conditional_sub_entities():
-                self.conditional_children.append((condition, [DescribedLaunchEntity(child) for child in sub_entities]))
+                self.conditional_children.append(
+                    (condition, [DescribedLaunchEntity(child) for child in sub_entities]))
 
         self.condition = None
         if isinstance(launch_entity, Action):
@@ -106,14 +113,16 @@ class DescribedLaunchEntity:
                 self.label = launch_entity.node_name
             except RuntimeError:
                 pass
-            self.description = 'package: {}, executable: {}'.format(launch_entity.node_package, launch_entity.node_executable)
+            self.description = 'package: {}, executable: {}'.format(
+                launch_entity.node_package, launch_entity.node_executable)
 
         elif isinstance(launch_entity, PushRosNamespace):
             self.label = describe_substitution(launch_entity.namespace, context)
             self.description = describe_substitution(launch_entity.namespace, None)
 
     def __repr__(self):
-        return 'id: {} ({}) name: {} desc: {}'.format(self.id, self.type_name, self.label, self.description)
+        return 'id: {} ({}) name: {} desc: {}'.format(
+            self.id, self.type_name, self.label, self.description)
 
 
 def describe_condition(condition: Condition, context: LaunchContext) -> str:

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -2,12 +2,11 @@
 from launch import Action
 from launch import Condition
 from launch import LaunchContext
-from launch import LaunchDescription
 from launch import LaunchDescriptionEntity
-from launch.launch_introspector import format_action
-from launch.launch_introspector import format_substitutions
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.launch_introspector import format_action
+from launch.launch_introspector import format_substitutions
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 

--- a/ros2launch_gui/api/describe.py
+++ b/ros2launch_gui/api/describe.py
@@ -17,7 +17,9 @@ from launch_ros.actions import SetParametersFromFile
 
 
 class DescribedLaunchEntity:
-    """A human readable description of launch entity and its children.
+    """
+    A human readable description of launch entity and its children.
+
     This is used to decouple the launch context from the description to be used
     in a GUI which may be running in a different thread.
     """

--- a/ros2launch_gui/events/query_user_interface.py
+++ b/ros2launch_gui/events/query_user_interface.py
@@ -1,6 +1,7 @@
 
 from launch import Event
 
+
 class QueryUserInterface(Event):
     """Event sent at regular interval to collect Actions from a user interface"""
 

--- a/ros2launch_gui/events/query_user_interface.py
+++ b/ros2launch_gui/events/query_user_interface.py
@@ -3,7 +3,7 @@ from launch import Event
 
 
 class QueryUserInterface(Event):
-    """Event sent at regular interval to collect Actions from a user interface"""
+    """Event sent at regular interval to collect Actions from a user interface."""
 
     name = 'ros2launch_gui.events.QueryUserInterface'
 

--- a/ros2launch_gui/option/gui.py
+++ b/ros2launch_gui/option/gui.py
@@ -1,10 +1,9 @@
 
-from launch import LaunchDescription
-
-from ros2launch_gui.actions import DisplayUserInterface
-from ros2launch.option import OptionExtension
-
 from typing import Tuple
+
+from launch import LaunchDescription
+from ros2launch.option import OptionExtension
+from ros2launch_gui.actions import DisplayUserInterface
 
 
 class GuiOption(OptionExtension):

--- a/ros2launch_gui/option/gui.py
+++ b/ros2launch_gui/option/gui.py
@@ -28,6 +28,4 @@ class GuiOption(OptionExtension):
                 ]
             ),
 
-        return launch_description, 
-
-
+        return launch_description,

--- a/ros2launch_gui/option/gui.py
+++ b/ros2launch_gui/option/gui.py
@@ -21,7 +21,7 @@ class GuiOption(OptionExtension):
         launch_description: LaunchDescription,
         args
     ) -> Tuple[LaunchDescription,]:
-        if(args.gui):
+        if args.gui:
             return LaunchDescription(
                 [
                     DisplayUserInterface(launch_description=launch_description, debug=args.debug),

--- a/ros2launch_gui/qt/__init__.py
+++ b/ros2launch_gui/qt/__init__.py
@@ -5,4 +5,4 @@ def __getattr__(name):
     if name == 'UserInterface':
         from .main import UserInterface
         return UserInterface
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/ros2launch_gui/qt/details_widget.py
+++ b/ros2launch_gui/qt/details_widget.py
@@ -4,6 +4,7 @@ from python_qt_binding.QtWidgets import QVBoxLayout
 
 from .process_output_widget import ProcessOutputWidget
 
+
 class DetailsWidget(QWidget):
     """A widget to manage and display detail widgets."""
 

--- a/ros2launch_gui/qt/details_widget.py
+++ b/ros2launch_gui/qt/details_widget.py
@@ -35,7 +35,8 @@ class DetailsWidget(QWidget):
             process_output_widget.hide()
             self.layout.addWidget(process_output_widget)
 
-        process_output_widget.on_process_io(process_name, f'Process {pid} started for {process_name}')
+        process_output_widget.on_process_io(
+            process_name, f'Process {pid} started for {process_name}')
 
     def on_process_io(self, process_name, text):
         self.all_process_output_widget.on_process_io(process_name, text)
@@ -44,7 +45,8 @@ class DetailsWidget(QWidget):
 
     def on_process_exited(self, process_name, return_code):
         if process_name in self.process_output_widgets:
-            self.process_output_widgets[process_name].on_process_io(process_name, f'Process exited with return code {return_code}')
+            self.process_output_widgets[process_name].on_process_io(
+                process_name, f'Process exited with return code {return_code}')
 
     def show_all_processes_output(self):
         self.current_widget.hide()

--- a/ros2launch_gui/qt/details_widget.py
+++ b/ros2launch_gui/qt/details_widget.py
@@ -1,6 +1,6 @@
 from python_qt_binding.QtWidgets import QPushButton
-from python_qt_binding.QtWidgets import QWidget
 from python_qt_binding.QtWidgets import QVBoxLayout
+from python_qt_binding.QtWidgets import QWidget
 
 from .process_output_widget import ProcessOutputWidget
 

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -58,7 +58,8 @@ class LaunchDescriptionWidget(QWidget):
             self.trees[tree_type].setObjectName(tree_type + '_tree')
             self.trees[tree_type].setVisible(False)
 
-        self.show_detailed_configuration_checkbox.stateChanged.connect(self.show_detailed_configuration_checkbox_state_changed)
+        self.show_detailed_configuration_checkbox.stateChanged.connect(
+            self.show_detailed_configuration_checkbox_state_changed)
         self.show_detailed_configuration_checkbox.setChecked(False)
 
         layout = QVBoxLayout()
@@ -123,7 +124,8 @@ class LaunchDescriptionWidget(QWidget):
         else:
             process_items = {}
             for item_label in self.tree_types:
-                process_items[item_label] = QTreeWidgetItem(['Process', 'running', process_name, f'PID: {pid}'])
+                process_items[item_label] = QTreeWidgetItem(
+                    ['Process', 'running', process_name, f'PID: {pid}'])
             self.process_items[process_name] = process_items
         if entity.id in self.entity_items:
             items = self.entity_items[entity.id]
@@ -175,7 +177,13 @@ class LaunchDescriptionWidget(QWidget):
                 )
             )
 
-    def on_entity_process_exited(self, entity: DescribedLaunchEntity, process_name: str, pid: int, return_code) -> None:
+    def on_entity_process_exited(
+            self,
+            entity: DescribedLaunchEntity,
+            process_name: str,
+            pid: int,
+            return_code
+    ) -> None:
         if process_name in self.process_items:
             items = self.process_items[process_name]
             for tree_type in self.tree_types:
@@ -208,7 +216,12 @@ class LaunchDescriptionWidget(QWidget):
         for child in launch_entity.children:
             self.updated_launch_entity(child)
 
-    def on_state_transition(self, entity: DescribedLaunchEntity, start_state: str, goal_state: str) -> None:
+    def on_state_transition(
+            self,
+            entity: DescribedLaunchEntity,
+            start_state: str,
+            goal_state: str
+    ) -> None:
         if entity.id in self.entity_items:
             items = self.entity_items[entity.id]
             for tree_type in self.tree_types:
@@ -220,7 +233,11 @@ class LaunchDescriptionWidget(QWidget):
                     else:
                         item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 150)))
                     if goal_state in self.lifecycle_transitions:
-                        item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, entity.label, goal_state))
+                        item.setData(
+                            0,
+                            self.ContextMenuRole,
+                            lambda menu: self.get_lifecycle_menu_items(
+                                menu, entity.label, goal_state))
                     else:
                         item.setData(0, self.ContextMenuRole, None)
 
@@ -242,7 +259,13 @@ class LaunchDescriptionWidget(QWidget):
                 if tree_type != 'simple' or launch_entity.type_name in ('Node', 'LifecycleNode'):
 
                     status_text = status if status is not None else ''
-                    item = QTreeWidgetItem([launch_entity.type_name, status_text, launch_entity.label, str(launch_entity.description), status])
+                    item = QTreeWidgetItem([
+                        launch_entity.type_name,
+                        status_text,
+                        launch_entity.label,
+                        str(launch_entity.description),
+                        status,
+                    ])
                     parent_item = None
                     expand_parent = True
                     if parent is not None:
@@ -251,8 +274,10 @@ class LaunchDescriptionWidget(QWidget):
                             if parent_item is not None:
                                 if launch_entity.type_name == 'DeclareLaunchArgument':
                                     if parent.id not in self.launch_arguments_items:
-                                        self.launch_arguments_items[parent.id] = QTreeWidgetItem(['Launch Arguments', '', '', ''])
-                                        parent_item.addChild(self.launch_arguments_items[parent.id])
+                                        self.launch_arguments_items[parent.id] = (
+                                            QTreeWidgetItem(['Launch Arguments', '', '', '']))
+                                        parent_item.addChild(
+                                            self.launch_arguments_items[parent.id])
                                     parent_item = self.launch_arguments_items[parent.id]
                                     expand_parent = False
                     if tree_type == 'detailed':
@@ -260,7 +285,8 @@ class LaunchDescriptionWidget(QWidget):
                             if launch_entity.id in self.entity_condition_items:
                                 condition_item = self.entity_condition_items[launch_entity.id]
                             else:
-                                condition_item = QTreeWidgetItem(['Condition', '', launch_entity.condition, ''])
+                                condition_item = QTreeWidgetItem(
+                                    ['Condition', '', launch_entity.condition, ''])
                                 self.entity_condition_items[launch_entity.id] = condition_item
                                 if parent_item is not None:
                                     parent_item.addChild(condition_item)
@@ -300,7 +326,11 @@ class LaunchDescriptionWidget(QWidget):
                 # assuming lifecycle node is unconfigured until we know otherwise
                 status = 'unconfigured'
             if status in self.lifecycle_transitions:
-                item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, launch_entity.label, status))
+                item.setData(
+                    0,
+                    self.ContextMenuRole,
+                    lambda menu: self.get_lifecycle_menu_items(
+                        menu, launch_entity.label, status))
 
     def show_context_menu(self, pos, tree):
         item = tree.itemAt(pos)

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -157,7 +157,7 @@ class LaunchDescriptionWidget(QWidget):
                     lambda: self._ui.add_pending_action(
                         EmitEvent(
                             event=SignalProcess(
-                                signal_number= signal.SIGINT,
+                                signal_number=signal.SIGINT,
                                 process_matcher=matches_pid(pid)
                             )
                         )
@@ -231,7 +231,7 @@ class LaunchDescriptionWidget(QWidget):
     def add_launch_entity_to_trees(
         self,
         launch_entity: DescribedLaunchEntity,
-        parent: DescribedLaunchEntity=None,
+        parent: DescribedLaunchEntity = None,
         status=None
     ):
         if launch_entity.id in self.entity_items:
@@ -254,7 +254,7 @@ class LaunchDescriptionWidget(QWidget):
                             parent_item = self.entity_items[parent.id][tree_type]
                             if parent_item is not None:
                                 if launch_entity.type_name == 'DeclareLaunchArgument':
-                                    if not parent.id in self.launch_arguments_items:
+                                    if parent.id not in self.launch_arguments_items:
                                         self.launch_arguments_items[parent.id] = QTreeWidgetItem(['Launch Arguments', '', '', ''])
                                         parent_item.addChild(self.launch_arguments_items[parent.id])
                                     parent_item = self.launch_arguments_items[parent.id]

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -21,7 +21,7 @@ from ros2launch_gui.api.describe import DescribedLaunchEntity
 class LaunchDescriptionWidget(QWidget):
     """
     A widget that displays a launch description as a tree.
-    
+
     The tree is updated when the launch is executed showing the status of processes.
     """
 

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -32,7 +32,6 @@ class LaunchDescriptionWidget(QWidget):
     DetailsCallbackRole = Qt.UserRole
     ContextMenuRole = Qt.UserRole + 1
 
-
     lifecycle_transitions = {
         'unconfigured': (
             ('Configure', Transition.TRANSITION_CONFIGURE),
@@ -63,10 +62,8 @@ class LaunchDescriptionWidget(QWidget):
             self.trees[tree_type].setObjectName(tree_type + '_tree')
             self.trees[tree_type].setVisible(False)
 
-
         self.show_detailed_configuration_checkbox.stateChanged.connect(self.show_detailed_configuration_checkbox_state_changed)
         self.show_detailed_configuration_checkbox.setChecked(False)
-
 
         layout = QVBoxLayout()
         layout.addWidget(self.show_detailed_configuration_checkbox)
@@ -103,7 +100,6 @@ class LaunchDescriptionWidget(QWidget):
         else:
             self.trees['detailed'].hide()
             self.trees['simple'].show()
-
 
     def on_item_selected(self, item, column):
         if item is not None:
@@ -183,7 +179,6 @@ class LaunchDescriptionWidget(QWidget):
                 )
             )
 
-
     def on_entity_process_exited(self, entity: DescribedLaunchEntity, process_name: str, pid: int, return_code) -> None:
         if process_name in self.process_items:
             items = self.process_items[process_name]
@@ -232,10 +227,6 @@ class LaunchDescriptionWidget(QWidget):
                         item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, entity.label, goal_state))
                     else:
                         item.setData(0, self.ContextMenuRole, None)
-
-
-
-
 
     def add_launch_entity_to_trees(
         self,
@@ -294,7 +285,6 @@ class LaunchDescriptionWidget(QWidget):
                     items[tree_type] = None
 
             self.entity_items[launch_entity.id] = items
-            
 
         for child in launch_entity.children:
             self.add_launch_entity_to_trees(child, launch_entity)
@@ -315,7 +305,6 @@ class LaunchDescriptionWidget(QWidget):
                 status = 'unconfigured'
             if status in self.lifecycle_transitions:
                 item.setData(0, self.ContextMenuRole, lambda menu: self.get_lifecycle_menu_items(menu, launch_entity.label, status))
-        
 
     def show_context_menu(self, pos, tree):
         item = tree.itemAt(pos)
@@ -325,4 +314,3 @@ class LaunchDescriptionWidget(QWidget):
                 menu = QMenu(self)
                 context_menu_callback(menu)
                 menu.exec_(tree.mapToGlobal(pos))
-

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -1,25 +1,21 @@
 import signal
 
-from typing import Callable
-
+from launch.actions import EmitEvent
+from launch.events.process import SignalProcess
+from launch.events.process.process_matchers import matches_pid
+from launch_ros.events import matches_node_name
+from launch_ros.events.lifecycle import ChangeState
+from lifecycle_msgs.msg import Transition
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtGui import QBrush
 from python_qt_binding.QtGui import QColor
 from python_qt_binding.QtWidgets import QCheckBox
 from python_qt_binding.QtWidgets import QMenu
-from python_qt_binding.QtWidgets import QTreeWidgetItem
 from python_qt_binding.QtWidgets import QTreeWidget
+from python_qt_binding.QtWidgets import QTreeWidgetItem
 from python_qt_binding.QtWidgets import QVBoxLayout
 from python_qt_binding.QtWidgets import QWidget
-
-from launch.actions import EmitEvent
-from launch.events.process import SignalProcess
-from launch.events.process.process_matchers import matches_pid
-from launch_ros.events.lifecycle import ChangeState
-from launch_ros.events import matches_node_name
 from ros2launch_gui.api.describe import DescribedLaunchEntity
-
-from lifecycle_msgs.msg import Transition
 
 
 class LaunchDescriptionWidget(QWidget):

--- a/ros2launch_gui/qt/launch_description_widget.py
+++ b/ros2launch_gui/qt/launch_description_widget.py
@@ -142,7 +142,7 @@ class LaunchDescriptionWidget(QWidget):
                     item.setExpanded(True)
                     item.setData(0, self.DetailsCallbackRole, selected_callback)
 
-            if entity.type_name == "LifecycleNode":
+            if entity.type_name == 'LifecycleNode':
                 self.on_state_transition(entity, 'unknown', 'unconfigured')
         else:
             for tree_type in self.tree_types:
@@ -210,7 +210,7 @@ class LaunchDescriptionWidget(QWidget):
                     item.setText(3, str(launch_entity.description))
                     if status is not None:
                         item.setText(1, status)
-                if launch_entity.type_name == "IncludeLaunchDescription":
+                if launch_entity.type_name == 'IncludeLaunchDescription':
                     for child in launch_entity.children:
                         if child.id not in self.entity_items:
                             self.add_launch_entity_to_trees(child, launch_entity)
@@ -252,7 +252,7 @@ class LaunchDescriptionWidget(QWidget):
         else:
             items = {}
             for tree_type in self.tree_types:
-                if tree_type != "simple" or launch_entity.type_name in ("Node", "LifecycleNode"):
+                if tree_type != 'simple' or launch_entity.type_name in ('Node', 'LifecycleNode'):
 
                     status_text = status if status is not None else ''
                     item = QTreeWidgetItem([launch_entity.type_name, status_text, launch_entity.label, str(launch_entity.description), status])
@@ -262,7 +262,7 @@ class LaunchDescriptionWidget(QWidget):
                         if parent.id in self.entity_items:
                             parent_item = self.entity_items[parent.id][tree_type]
                             if parent_item is not None:
-                                if launch_entity.type_name == "DeclareLaunchArgument":
+                                if launch_entity.type_name == 'DeclareLaunchArgument':
                                     if not parent.id in self.launch_arguments_items:
                                         self.launch_arguments_items[parent.id] = QTreeWidgetItem(['Launch Arguments', '', '', ''])
                                         parent_item.addChild(self.launch_arguments_items[parent.id])
@@ -308,7 +308,7 @@ class LaunchDescriptionWidget(QWidget):
         item: QTreeWidgetItem,
         status: str
     ):
-        if launch_entity.type_name == "LifecycleNode":
+        if launch_entity.type_name == 'LifecycleNode':
             item.setData(1, Qt.BackgroundRole, QBrush(QColor(255, 255, 150)))
             if status is None:
                 # assuming lifecycle node is unconfigured until we know otherwise

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -14,7 +14,7 @@ class MainWindow(QMainWindow):
         super().__init__()
 
         self._ui = ui
-        self.setWindowTitle("ROS 2 Launch GUI")
+        self.setWindowTitle('ROS 2 Launch GUI')
         self.launch_description_widget = LaunchDescriptionWidget(ui, self)
         self.details_widget = DetailsWidget(self)
 

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -10,7 +10,7 @@ from .launch_description_widget import LaunchDescriptionWidget
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, ui: 'UserInterface'=None):
+    def __init__(self, ui: 'UserInterface' = None):
         super().__init__()
 
         self._ui = ui

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -27,11 +27,16 @@ class MainWindow(QMainWindow):
 
     def on_process_started(self, action, process_name, pid):
         self.details_widget.on_process_started(process_name, pid)
-        self.launch_description_widget.on_entity_process_started(action, process_name, pid, lambda: self.details_widget.show_process_output(process_name))
+        self.launch_description_widget.on_entity_process_started(
+            action,
+            process_name,
+            pid,
+            lambda: self.details_widget.show_process_output(process_name))
 
     def on_process_exited(self, action, process_name, pid, return_code):
         self.details_widget.on_process_exited(process_name, return_code)
-        self.launch_description_widget.on_entity_process_exited(action, process_name, pid, return_code)
+        self.launch_description_widget.on_entity_process_exited(
+            action, process_name, pid, return_code)
 
     def on_process_io(self, process_name, text):
         self.details_widget.on_process_io(process_name, text)

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -22,7 +22,6 @@ class MainWindow(QMainWindow):
         splitter.addWidget(self.launch_description_widget)
         splitter.addWidget(self.details_widget)
 
-
         self.setCentralWidget(splitter)
         self.show()
 

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -1,12 +1,11 @@
+from launch import LaunchDescription
 from python_qt_binding.QtWidgets import QApplication
 from python_qt_binding.QtWidgets import QMainWindow
 from python_qt_binding.QtWidgets import QSplitter
 
-from launch import LaunchDescription
-
-from ..api import UserInterface as UserInterfaceBase
 from .details_widget import DetailsWidget
 from .launch_description_widget import LaunchDescriptionWidget
+from ..api import UserInterface as UserInterfaceBase
 
 
 class MainWindow(QMainWindow):

--- a/ros2launch_gui/qt/main.py
+++ b/ros2launch_gui/qt/main.py
@@ -10,6 +10,7 @@ from .launch_description_widget import LaunchDescriptionWidget
 
 
 class MainWindow(QMainWindow):
+
     def __init__(self, ui: 'UserInterface' = None):
         super().__init__()
 

--- a/ros2launch_gui/qt/process_output_widget.py
+++ b/ros2launch_gui/qt/process_output_widget.py
@@ -22,7 +22,6 @@ class ProcessOutputWidget(QWidget):
         self.setLayout(layout)
         self.text_edit.show()
 
-
     def on_process_io(self, process_name, text):
         for line in text.split('\n'):
             line = line.rstrip()

--- a/ros2launch_gui/qt/process_output_widget.py
+++ b/ros2launch_gui/qt/process_output_widget.py
@@ -8,7 +8,7 @@ from ros2launch_gui.ansi import ansi_to_html
 class ProcessOutputWidget(QWidget):
     """Widget to display output from launch processes."""
 
-    def __init__(self, parent, show_process_name = True):
+    def __init__(self, parent, show_process_name=True):
         """Create a ProcessOutputWidget."""
         super().__init__(parent)
 

--- a/ros2launch_gui/tk/__init__.py
+++ b/ros2launch_gui/tk/__init__.py
@@ -5,4 +5,4 @@ def __getattr__(name):
     if name == 'UserInterface':
         from .user_interface import UserInterface
         return UserInterface
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/ros2launch_gui/tk/launch_description_treeview.py
+++ b/ros2launch_gui/tk/launch_description_treeview.py
@@ -2,6 +2,7 @@ from tkinter import ttk
 
 from ros2launch_gui.api.describe import DescribedLaunchEntity
 
+
 class LaunchDescriptionTreeview(ttk.Frame):
     """A widget that displays a launch description as a tree."""
 
@@ -27,12 +28,10 @@ class LaunchDescriptionTreeview(ttk.Frame):
 
         self.tree.bind('<<TreeviewSelect>>', self.on_tree_item_selected)
 
-
-
     def add_process_selected_callback(self, callback):
         self.process_selected_callbacks.append(callback)
 
-    def on_describe_launch_entity(self, entity: DescribedLaunchEntity) -> None:        
+    def on_describe_launch_entity(self, entity: DescribedLaunchEntity) -> None:
         self.add_launch_entity_to_tree(entity)
 
     def on_execution_complete(self, entity: DescribedLaunchEntity) -> None:

--- a/ros2launch_gui/tk/launch_description_treeview.py
+++ b/ros2launch_gui/tk/launch_description_treeview.py
@@ -25,7 +25,7 @@ class LaunchDescriptionTreeview(ttk.Frame):
 
         self.process_selected_callbacks = []
 
-        self.tree.bind("<<TreeviewSelect>>", self.on_tree_item_selected)
+        self.tree.bind('<<TreeviewSelect>>', self.on_tree_item_selected)
 
 
 
@@ -42,7 +42,7 @@ class LaunchDescriptionTreeview(ttk.Frame):
         if entity.id in self.tree_ids:
             item_id = self.tree_ids[entity.id]
             self.tree.item(item_id, open=True)
-            self.process_ids[process_name] = self.tree.insert(item_id, 'end', text="Process", values=(process_name, 'PID: {}'.format(pid), 'running'))
+            self.process_ids[process_name] = self.tree.insert(item_id, 'end', text='Process', values=(process_name, 'PID: {}'.format(pid), 'running'))
 
     def on_entity_process_exited(self, entity: DescribedLaunchEntity, process_name: str, pid: int, return_code) -> None:
         if process_name in self.process_ids:
@@ -54,7 +54,7 @@ class LaunchDescriptionTreeview(ttk.Frame):
             item_id = self.tree_ids[launch_entity.id]
             status_text = status if status is not None else ''
             self.tree.item(item_id, values=(launch_entity.label, launch_entity.description, status_text))
-            if launch_entity.type_name == "IncludeLaunchDescription":
+            if launch_entity.type_name == 'IncludeLaunchDescription':
                 for child in launch_entity.children:
                     if child.id not in self.tree_ids:
                         self.add_launch_entity_to_tree(child, item_id)

--- a/ros2launch_gui/tk/launch_description_treeview.py
+++ b/ros2launch_gui/tk/launch_description_treeview.py
@@ -37,22 +37,40 @@ class LaunchDescriptionTreeview(ttk.Frame):
     def on_execution_complete(self, entity: DescribedLaunchEntity) -> None:
         self.updated_launch_entity(entity, status='done')
 
-    def on_entity_process_started(self, entity: DescribedLaunchEntity, process_name: str, pid: int) -> None:
+    def on_entity_process_started(
+            self,
+            entity: DescribedLaunchEntity,
+            process_name: str,
+            pid: int
+    ) -> None:
         if entity.id in self.tree_ids:
             item_id = self.tree_ids[entity.id]
             self.tree.item(item_id, open=True)
-            self.process_ids[process_name] = self.tree.insert(item_id, 'end', text='Process', values=(process_name, 'PID: {}'.format(pid), 'running'))
+            self.process_ids[process_name] = self.tree.insert(
+                item_id,
+                'end',
+                text='Process',
+                values=(process_name, 'PID: {}'.format(pid), 'running'))
 
-    def on_entity_process_exited(self, entity: DescribedLaunchEntity, process_name: str, pid: int, return_code) -> None:
+    def on_entity_process_exited(
+            self,
+            entity: DescribedLaunchEntity,
+            process_name: str,
+            pid: int,
+            return_code
+    ) -> None:
         if process_name in self.process_ids:
             item_id = self.process_ids[process_name]
-            self.tree.item(item_id, values=(process_name, 'PID: {}'.format(pid), 'exit: {}'.format(return_code)))
+            self.tree.item(
+                item_id,
+                values=(process_name, 'PID: {}'.format(pid), 'exit: {}'.format(return_code)))
 
     def updated_launch_entity(self, launch_entity: DescribedLaunchEntity, status=None):
         if launch_entity.id in self.tree_ids:
             item_id = self.tree_ids[launch_entity.id]
             status_text = status if status is not None else ''
-            self.tree.item(item_id, values=(launch_entity.label, launch_entity.description, status_text))
+            self.tree.item(
+                item_id, values=(launch_entity.label, launch_entity.description, status_text))
             if launch_entity.type_name == 'IncludeLaunchDescription':
                 for child in launch_entity.children:
                     if child.id not in self.tree_ids:
@@ -72,7 +90,8 @@ class LaunchDescriptionTreeview(ttk.Frame):
             item_id = self.tree.insert(parent, 'end', text=launch_entity.type_name, open=True)
             self.tree_ids[launch_entity.id] = item_id
         status_text = status if status is not None else ''
-        self.tree.item(item_id, values=(launch_entity.label, launch_entity.description, status_text))
+        self.tree.item(
+            item_id, values=(launch_entity.label, launch_entity.description, status_text))
         for child in launch_entity.children:
             self.add_launch_entity_to_tree(child, item_id)
 

--- a/ros2launch_gui/tk/process_manager.py
+++ b/ros2launch_gui/tk/process_manager.py
@@ -24,7 +24,7 @@ class ProcessList(ttk.Frame):
         self.tree_ids = {}
 
     def get_item_id(self, process_name: str) -> str:
-        if not process_name in self.tree_ids:
+        if process_name not in self.tree_ids:
             self.tree_ids[process_name] = self.tree.insert('', 'end', text=process_name, values=(0, 'unknown'))
         return self.tree_ids[process_name]
 
@@ -66,7 +66,7 @@ class ProcessIOView(ttk.Frame):
                 self.text.insert('end', '[{}] {}\n'.format(process_name, line))
         else:
             self.text.insert('end', data)
-        #self.text.see('end')
+        # self.text.see('end')
         self.text.config(state='disabled')
 
 

--- a/ros2launch_gui/tk/process_manager.py
+++ b/ros2launch_gui/tk/process_manager.py
@@ -3,6 +3,7 @@ from tkinter.scrolledtext import ScrolledText
 
 from ros2launch_gui.api.describe import DescribedLaunchEntity
 
+
 class ProcessList(ttk.Frame):
     """A widget that displays a list of launch processes and their status."""
 
@@ -22,12 +23,10 @@ class ProcessList(ttk.Frame):
 
         self.tree_ids = {}
 
-
     def get_item_id(self, process_name: str) -> str:
         if not process_name in self.tree_ids:
             self.tree_ids[process_name] = self.tree.insert('', 'end', text=process_name, values=(0, 'unknown'))
         return self.tree_ids[process_name]
-
 
     def on_process_started(
             self,
@@ -48,6 +47,7 @@ class ProcessList(ttk.Frame):
         item_id = self.get_item_id(process_name)
         self.tree.item(item_id, values=(pid, 'exit: {}'.format(return_code)))
 
+
 class ProcessIOView(ttk.Frame):
     def __init__(self, parent=None, show_process_name: bool = False):
         super().__init__(parent)
@@ -59,7 +59,6 @@ class ProcessIOView(ttk.Frame):
 
         self.show_process_name = show_process_name
 
-
     def on_process_io(self, process_name: str, data: str) -> None:
         self.text.config(state='normal')
         if self.show_process_name:
@@ -69,6 +68,7 @@ class ProcessIOView(ttk.Frame):
             self.text.insert('end', data)
         #self.text.see('end')
         self.text.config(state='disabled')
+
 
 class ProcessIONotebook(ttk.Frame):
     def __init__(self, parent=None):
@@ -126,6 +126,7 @@ class ProcessIONotebook(ttk.Frame):
         if process_name in self.io_widgets:
             io_widget = self.io_widgets[process_name]
             io_widget.on_process_io(process_name, 'Process {} exited with return code: {}\n'.format(pid, return_code))
+
 
 class ProcessManager(ttk.Frame):
     """A widget that displays a list of launch processes as well as their output in a tabbed display."""

--- a/ros2launch_gui/tk/process_manager.py
+++ b/ros2launch_gui/tk/process_manager.py
@@ -49,6 +49,7 @@ class ProcessList(ttk.Frame):
 
 
 class ProcessIOView(ttk.Frame):
+
     def __init__(self, parent=None, show_process_name: bool = False):
         super().__init__(parent)
 
@@ -71,6 +72,7 @@ class ProcessIOView(ttk.Frame):
 
 
 class ProcessIONotebook(ttk.Frame):
+
     def __init__(self, parent=None):
         super().__init__(parent)
 

--- a/ros2launch_gui/tk/process_manager.py
+++ b/ros2launch_gui/tk/process_manager.py
@@ -25,7 +25,8 @@ class ProcessList(ttk.Frame):
 
     def get_item_id(self, process_name: str) -> str:
         if process_name not in self.tree_ids:
-            self.tree_ids[process_name] = self.tree.insert('', 'end', text=process_name, values=(0, 'unknown'))
+            self.tree_ids[process_name] = self.tree.insert(
+                '', 'end', text=process_name, values=(0, 'unknown'))
         return self.tree_ids[process_name]
 
     def on_process_started(
@@ -116,7 +117,8 @@ class ProcessIONotebook(ttk.Frame):
             io_widget = ProcessIOView(self)
             self.io_widgets[process_name] = io_widget
             self.notebook.add(io_widget, text=process_name)
-        io_widget.on_process_io(process_name, 'Process {} started for action: {}\n'.format(pid, action))
+        io_widget.on_process_io(
+            process_name, 'Process {} started for action: {}\n'.format(pid, action))
 
     def on_process_exited(
             self,
@@ -127,11 +129,13 @@ class ProcessIONotebook(ttk.Frame):
     ) -> None:
         if process_name in self.io_widgets:
             io_widget = self.io_widgets[process_name]
-            io_widget.on_process_io(process_name, 'Process {} exited with return code: {}\n'.format(pid, return_code))
+            io_widget.on_process_io(
+                process_name,
+                'Process {} exited with return code: {}\n'.format(pid, return_code))
 
 
 class ProcessManager(ttk.Frame):
-    """A widget that displays a list of launch processes as well as their output in a tabbed display."""
+    """A widget that displays a list of launch processes and their output in a tabbed display."""
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/ros2launch_gui/tk/user_interface.py
+++ b/ros2launch_gui/tk/user_interface.py
@@ -3,10 +3,10 @@ from tkinter import ttk
 
 from launch import LaunchDescription
 
-from ..api import DescribedLaunchEntity
-from ..api import UserInterface as UserInterfaceBase
 from .launch_description_treeview import LaunchDescriptionTreeview
 from .process_manager import ProcessManager
+from ..api import DescribedLaunchEntity
+from ..api import UserInterface as UserInterfaceBase
 
 
 class UserInterface(UserInterfaceBase):

--- a/ros2launch_gui/tk/user_interface.py
+++ b/ros2launch_gui/tk/user_interface.py
@@ -17,11 +17,11 @@ class UserInterface(UserInterfaceBase):
     ):
         super().__init__(launch_description, debug)
         self.root = Tk()
-        self.root.title("ROS 2 Launch GUI")
+        self.root.title('ROS 2 Launch GUI')
         self.root.grid_rowconfigure(0, weight=1)
         self.root.grid_columnconfigure(0, weight=1)
 
-        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+        self.root.protocol('WM_DELETE_WINDOW', self.on_close)
 
         main_window = ttk.PanedWindow(self.root, orient='horizontal')
         main_window.grid(column=0, row=0, sticky=('N', 'W', 'E', 'S'))

--- a/ros2launch_gui/tui/output_view.py
+++ b/ros2launch_gui/tui/output_view.py
@@ -4,7 +4,8 @@ import urwid
 
 
 class OutputView(urwid.ListBox):
-    """Log output view with per-process and total scrollback caps.
+    """
+    Log output view with per-process and total scrollback caps.
 
     Lines are stored in both a global deque and per-process deques.  Selecting
     the backing deque for a given filter is O(1), and rebuilding the visible

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -1,37 +1,37 @@
 from ros2launch_gui.ansi import ansi_to_html
 
 def test_plain_text_to_html():
-    input = "my text"
+    input = 'my text'
     assert ansi_to_html(input) == input
 
 def test_info_text_to_html():
-    input = "\033[0m[INFO] my text\033[0m"
+    input = '\033[0m[INFO] my text\033[0m'
     expected = '[INFO] my text'
     assert ansi_to_html(input) == expected
 
 def test_colored_text_to_html():
-    input = "\033[31mmy text\033[0m"
+    input = '\033[31mmy text\033[0m'
     expected = '<span style="color: #FF0000">my text</span>'
     assert ansi_to_html(input) == expected
 
 def test_bold_colored_text_to_html():
-    input = "\033[1;32mmy text\033[0m"
+    input = '\033[1;32mmy text\033[0m'
     expected = '<span style="color: #00FF00"><b>my text</b></span>'
     assert ansi_to_html(input) == expected
 
 def test_underlined_colored_text_to_html():
-    input = "\033[4;34mmy text\033[0m"
+    input = '\033[4;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><u>my text</u></span>'
     assert ansi_to_html(input) == expected
 
 def test_italic_colored_text_to_html():
-    input = "\033[3;34mmy text\033[0m"
+    input = '\033[3;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><i>my text</i></span>'
     assert ansi_to_html(input) == expected
 
 def test_multi_segment_line():
     """Multiple color regions on one line (typical ROS 2 output)."""
-    input = "\033[32m[INFO]\033[0m \033[36m[node]\033[0m: msg"
+    input = '\033[32m[INFO]\033[0m \033[36m[node]\033[0m: msg'
     expected = (
         '<span style="color: #00FF00">[INFO]</span>'
         ' '
@@ -42,7 +42,7 @@ def test_multi_segment_line():
 
 def test_mid_line_color_change_no_reset():
     """Color changes mid-line without reset in between."""
-    input = "\033[31mred\033[32mgreen\033[0m"
+    input = '\033[31mred\033[32mgreen\033[0m'
     expected = (
         '<span style="color: #FF0000">red</span>'
         '<span style="color: #00FF00">green</span>'
@@ -51,25 +51,25 @@ def test_mid_line_color_change_no_reset():
 
 def test_only_reset_codes():
     """Reset codes around plain text produce unstyled output."""
-    input = "\033[0mplain text\033[0m"
+    input = '\033[0mplain text\033[0m'
     expected = 'plain text'
     assert ansi_to_html(input) == expected
 
 def test_unknown_256_color_code():
     """Unknown 256-color code is stripped; text rendered without styling."""
-    input = "\033[38;5;196mtext\033[0m"
+    input = '\033[38;5;196mtext\033[0m'
     expected = 'text'
     assert ansi_to_html(input) == expected
 
 def test_consecutive_resets():
     """Multiple consecutive resets before text."""
-    input = "\033[0m\033[0mtext"
+    input = '\033[0m\033[0mtext'
     expected = 'text'
     assert ansi_to_html(input) == expected
 
 def test_modifier_with_multi_segment():
     """Modifiers combined with colors across multiple segments."""
-    input = "\033[1;31mbold red\033[0m normal \033[4;34munderline blue\033[0m"
+    input = '\033[1;31mbold red\033[0m normal \033[4;34munderline blue\033[0m'
     expected = (
         '<span style="color: #FF0000"><b>bold red</b></span>'
         ' normal '

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -1,33 +1,40 @@
 from ros2launch_gui.ansi import ansi_to_html
 
+
 def test_plain_text_to_html():
     input = 'my text'
     assert ansi_to_html(input) == input
+
 
 def test_info_text_to_html():
     input = '\033[0m[INFO] my text\033[0m'
     expected = '[INFO] my text'
     assert ansi_to_html(input) == expected
 
+
 def test_colored_text_to_html():
     input = '\033[31mmy text\033[0m'
     expected = '<span style="color: #FF0000">my text</span>'
     assert ansi_to_html(input) == expected
+
 
 def test_bold_colored_text_to_html():
     input = '\033[1;32mmy text\033[0m'
     expected = '<span style="color: #00FF00"><b>my text</b></span>'
     assert ansi_to_html(input) == expected
 
+
 def test_underlined_colored_text_to_html():
     input = '\033[4;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><u>my text</u></span>'
     assert ansi_to_html(input) == expected
 
+
 def test_italic_colored_text_to_html():
     input = '\033[3;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><i>my text</i></span>'
     assert ansi_to_html(input) == expected
+
 
 def test_multi_segment_line():
     """Multiple color regions on one line (typical ROS 2 output)."""
@@ -40,6 +47,7 @@ def test_multi_segment_line():
     )
     assert ansi_to_html(input) == expected
 
+
 def test_mid_line_color_change_no_reset():
     """Color changes mid-line without reset in between."""
     input = '\033[31mred\033[32mgreen\033[0m'
@@ -49,11 +57,13 @@ def test_mid_line_color_change_no_reset():
     )
     assert ansi_to_html(input) == expected
 
+
 def test_only_reset_codes():
     """Reset codes around plain text produce unstyled output."""
     input = '\033[0mplain text\033[0m'
     expected = 'plain text'
     assert ansi_to_html(input) == expected
+
 
 def test_unknown_256_color_code():
     """Unknown 256-color code is stripped; text rendered without styling."""
@@ -61,11 +71,13 @@ def test_unknown_256_color_code():
     expected = 'text'
     assert ansi_to_html(input) == expected
 
+
 def test_consecutive_resets():
     """Multiple consecutive resets before text."""
     input = '\033[0m\033[0mtext'
     expected = 'text'
     assert ansi_to_html(input) == expected
+
 
 def test_modifier_with_multi_segment():
     """Modifiers combined with colors across multiple segments."""

--- a/test/test_ansi_to_html.py
+++ b/test/test_ansi_to_html.py
@@ -2,89 +2,89 @@ from ros2launch_gui.ansi import ansi_to_html
 
 
 def test_plain_text_to_html():
-    input = 'my text'
-    assert ansi_to_html(input) == input
+    text = 'my text'
+    assert ansi_to_html(text) == text
 
 
 def test_info_text_to_html():
-    input = '\033[0m[INFO] my text\033[0m'
+    text = '\033[0m[INFO] my text\033[0m'
     expected = '[INFO] my text'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_colored_text_to_html():
-    input = '\033[31mmy text\033[0m'
+    text = '\033[31mmy text\033[0m'
     expected = '<span style="color: #FF0000">my text</span>'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_bold_colored_text_to_html():
-    input = '\033[1;32mmy text\033[0m'
+    text = '\033[1;32mmy text\033[0m'
     expected = '<span style="color: #00FF00"><b>my text</b></span>'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_underlined_colored_text_to_html():
-    input = '\033[4;34mmy text\033[0m'
+    text = '\033[4;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><u>my text</u></span>'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_italic_colored_text_to_html():
-    input = '\033[3;34mmy text\033[0m'
+    text = '\033[3;34mmy text\033[0m'
     expected = '<span style="color: #0000FF"><i>my text</i></span>'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_multi_segment_line():
     """Multiple color regions on one line (typical ROS 2 output)."""
-    input = '\033[32m[INFO]\033[0m \033[36m[node]\033[0m: msg'
+    text = '\033[32m[INFO]\033[0m \033[36m[node]\033[0m: msg'
     expected = (
         '<span style="color: #00FF00">[INFO]</span>'
         ' '
         '<span style="color: #00FFFF">[node]</span>'
         ': msg'
     )
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_mid_line_color_change_no_reset():
     """Color changes mid-line without reset in between."""
-    input = '\033[31mred\033[32mgreen\033[0m'
+    text = '\033[31mred\033[32mgreen\033[0m'
     expected = (
         '<span style="color: #FF0000">red</span>'
         '<span style="color: #00FF00">green</span>'
     )
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_only_reset_codes():
     """Reset codes around plain text produce unstyled output."""
-    input = '\033[0mplain text\033[0m'
+    text = '\033[0mplain text\033[0m'
     expected = 'plain text'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_unknown_256_color_code():
     """Unknown 256-color code is stripped; text rendered without styling."""
-    input = '\033[38;5;196mtext\033[0m'
+    text = '\033[38;5;196mtext\033[0m'
     expected = 'text'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_consecutive_resets():
     """Multiple consecutive resets before text."""
-    input = '\033[0m\033[0mtext'
+    text = '\033[0m\033[0mtext'
     expected = 'text'
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected
 
 
 def test_modifier_with_multi_segment():
     """Modifiers combined with colors across multiple segments."""
-    input = '\033[1;31mbold red\033[0m normal \033[4;34munderline blue\033[0m'
+    text = '\033[1;31mbold red\033[0m normal \033[4;34munderline blue\033[0m'
     expected = (
         '<span style="color: #FF0000"><b>bold red</b></span>'
         ' normal '
         '<span style="color: #0000FF"><u>underline blue</u></span>'
     )
-    assert ansi_to_html(input) == expected
+    assert ansi_to_html(text) == expected


### PR DESCRIPTION
## Summary

Mechanical lint cleanup. **No behavioural change.**

| Linter | Before | After |
|---|---|---|
| `ament_flake8` | **156** errors, 15 files | **0** (35 files checked) |
| `ament_pep257` | **10** errors | **0** |

Suite: **20 tests, 0 errors, 0 failures, 1 skipped** (the skip is `test_copyright`, already `@pytest.mark.skip` on `jazzy` — untouched).

## Why now

This repo has **no `.github/` workflows**, so under [ADR-0018](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0018-local-first-ci-verification.md) the merge gate for a project repo is a full-scope `ci_local.sh` attestation — and that runs `colcon test --return-code-on-test-failure`. With the lint tests red on the base, **no PR in this repo could produce a passing attestation.** This lands first so #30 (the poll-loop handler leak) merges onto a genuinely green base instead of needing a documented exception.

## Ten atomic commits, one per error class

`a4cb4dd` Q000 (single quotes) · `b454186` blank lines / trailing whitespace · `07943d7` operator+comment spacing, membership tests · `db92cc1` CNL100 · `7528e2e` import order + unused imports · `7438960` F841 · `e994469` A001 · `6c2235b` docstrings · `4efb03b` E501 · `62c6cee` progress entry.

The real class set was slightly wider than the issue's breakdown — **A001 (12)**, **CNL100 (3)**, **F401 (2)**, **E713 (2)** and the D-codes also had to go.

## Style-only, proven rather than asserted

After the E501 wrap pass, each changed file's Python **token stream** was compared against its previous revision with `tokenize`. Across all seven files the only non-whitespace deltas were:

- one added trailing comma inside a list literal,
- two grouping parentheses,
- one docstring word (below).

`autopep8` was used only with narrow `--select` sets (blank-line/whitespace, then spacing). **`black` was never run** — it normalizes quotes the opposite way to ROS 2 style and would have reformatted far more.

## The judgement calls, called out

- **3 × F841** — all `except Exception as e:` in `api/describe.py` where `e` is never read, each with a well-defined fallback already in place. Bindings deleted rather than used.
- **12 × A001** — `input` shadows the builtin in every test in `test_ansi_to_html.py`. Renamed the test-local to `text`; assertions unchanged. A rename, but test-local and unavoidable for a clean run.
- **One docstring word** — `ProcessManager`'s docstring was 103 columns; reflowing tripped D205/D400, so "as well as" → "and". The only wording change in the diff.
- **`if(args.gui):`** — `autopep8` produced `if (args.gui):`; the redundant parens were dropped for `if args.gui:`.

## Flagged, deliberately NOT fixed here

While removing the F841 bindings: the `IncludeLaunchDescription` handler in `api/describe.py` swallows its exception with **no diagnostic at all**, while the sibling handler ~13 lines above surfaces `str(e)` as the entity description. A launch file that fails to resolve therefore renders as a childless node with no hint why.

That asymmetry looks like a genuine observability gap, but surfacing the error is a **behaviour change** and out of scope for a style-only PR. Filed separately (see linked issue) and noted in `7438960`'s commit message.

## Test plan

```
ament_flake8   -> clean
ament_pep257   -> clean
./underlay_ws/build.sh ros2launch_gui   -> Finished
./underlay_ws/test.sh  ros2launch_gui   -> 20 tests, 0 errors, 0 failures, 1 skipped
```

Closes #31

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
